### PR TITLE
Upgrade filestorage to v1.7.0 and add Taski–Exesh A+B e2e

### DIFF
--- a/Exesh/go.mod
+++ b/Exesh/go.mod
@@ -3,7 +3,7 @@ module exesh
 go 1.24.0
 
 require (
-	github.com/DIvanCode/filestorage v1.6.0
+	github.com/DIvanCode/filestorage v1.7.0
 	github.com/go-chi/chi/v5 v5.2.3
 	github.com/go-chi/render v1.0.3
 	github.com/google/uuid v1.6.0

--- a/Exesh/go.sum
+++ b/Exesh/go.sum
@@ -1,7 +1,7 @@
 github.com/BurntSushi/toml v1.2.1 h1:9F2/+DoOYIOksmaJFPw1tGFy1eDnIJXg+UHjuD8lTak=
 github.com/BurntSushi/toml v1.2.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
-github.com/DIvanCode/filestorage v1.6.0 h1:Ffq0y/CP0J7tqhB6xL2ROgASbu7xHCn6L1G+95Z9OXM=
-github.com/DIvanCode/filestorage v1.6.0/go.mod h1:Vmhj19y+JR4bBI7VmF28S/70SKpkBCBp4YdhOB2PHTs=
+github.com/DIvanCode/filestorage v1.7.0 h1:HacZaIU4kju4VZCO584Yxgh+4fNJWNJ0gsAkX5B/pD4=
+github.com/DIvanCode/filestorage v1.7.0/go.mod h1:Vmhj19y+JR4bBI7VmF28S/70SKpkBCBp4YdhOB2PHTs=
 github.com/ajg/form v1.5.1 h1:t9c7v8JUKu/XxOGBU0yjNpaMloxGEJhUkqFRq0ibGeU=
 github.com/ajg/form v1.5.1/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=

--- a/Taski/go.mod
+++ b/Taski/go.mod
@@ -3,7 +3,7 @@ module taski
 go 1.24.0
 
 require (
-	github.com/DIvanCode/filestorage v1.6.0
+	github.com/DIvanCode/filestorage v1.7.0
 	github.com/go-chi/chi v1.5.5
 	github.com/go-chi/chi/v5 v5.2.3
 	github.com/go-chi/cors v1.2.2

--- a/Taski/go.sum
+++ b/Taski/go.sum
@@ -1,7 +1,7 @@
 github.com/BurntSushi/toml v1.2.1 h1:9F2/+DoOYIOksmaJFPw1tGFy1eDnIJXg+UHjuD8lTak=
 github.com/BurntSushi/toml v1.2.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
-github.com/DIvanCode/filestorage v1.6.0 h1:Ffq0y/CP0J7tqhB6xL2ROgASbu7xHCn6L1G+95Z9OXM=
-github.com/DIvanCode/filestorage v1.6.0/go.mod h1:Vmhj19y+JR4bBI7VmF28S/70SKpkBCBp4YdhOB2PHTs=
+github.com/DIvanCode/filestorage v1.7.0 h1:HacZaIU4kju4VZCO584Yxgh+4fNJWNJ0gsAkX5B/pD4=
+github.com/DIvanCode/filestorage v1.7.0/go.mod h1:Vmhj19y+JR4bBI7VmF28S/70SKpkBCBp4YdhOB2PHTs=
 github.com/ajg/form v1.5.1 h1:t9c7v8JUKu/XxOGBU0yjNpaMloxGEJhUkqFRq0ibGeU=
 github.com/ajg/form v1.5.1/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=

--- a/e2e/taski-exesh/Dockerfile
+++ b/e2e/taski-exesh/Dockerfile
@@ -1,0 +1,8 @@
+FROM golang:1.24-alpine
+
+WORKDIR /test
+
+COPY go.mod ./
+COPY taski_exesh_test.go ./
+
+CMD ["go", "test", "-v", "-count=1", "-timeout=10m", "./..."]

--- a/e2e/taski-exesh/README.md
+++ b/e2e/taski-exesh/README.md
@@ -1,0 +1,15 @@
+# Taski → Exesh A+B end-to-end test
+
+The test starts an isolated Taski/Exesh stack, submits a correct C++ A+B
+solution with a random solution ID, and polls Taski's REST API until the last
+stored message is `finish` with the `Accepted` verdict.
+
+Run it from the Backend repository:
+
+```sh
+./e2e/taski-exesh/run.sh
+```
+
+The Compose project uses no host ports or fixed container names, so it can run
+alongside the regular local CoDuels stack. Containers, networks, and volumes
+created by the test are removed when it finishes.

--- a/e2e/taski-exesh/compose.yml
+++ b/e2e/taski-exesh/compose.yml
@@ -1,0 +1,105 @@
+services:
+  exesh-postgres:
+    image: postgres:17.7
+    environment:
+      POSTGRES_USER: coordinator
+      POSTGRES_PASSWORD: secret
+      POSTGRES_DB: exesh
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U coordinator -d exesh"]
+      interval: 1s
+      timeout: 3s
+      retries: 60
+    volumes:
+      - exesh-postgres:/var/lib/postgresql/data
+
+  taski-postgres:
+    image: postgres:17.7
+    environment:
+      POSTGRES_USER: taski
+      POSTGRES_PASSWORD: secret
+      POSTGRES_DB: taski
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U taski -d taski"]
+      interval: 1s
+      timeout: 3s
+      retries: 60
+    volumes:
+      - taski-postgres:/var/lib/postgresql/data
+
+  coordinator:
+    image: coduels-exesh-e2e:local
+    build:
+      context: ../../Exesh
+      dockerfile: Dockerfile
+    command: ["/app/bin/coordinator"]
+    environment:
+      CONFIG_PATH: /config/coordinator.yml
+    depends_on:
+      exesh-postgres:
+        condition: service_healthy
+    volumes:
+      - ./config/coordinator.yml:/config/coordinator.yml:ro
+      - coordinator-storage:/var/lib/coduels/coordinator
+
+  worker:
+    image: coduels-exesh-e2e:local
+    build:
+      context: ../../Exesh
+      dockerfile: Dockerfile
+    command: ["/app/bin/worker"]
+    environment:
+      CONFIG_PATH: /config/worker.yml
+    depends_on:
+      coordinator:
+        condition: service_started
+    privileged: true
+    volumes:
+      - ./config/worker.yml:/config/worker.yml:ro
+      - ../../Exesh/config/isolate.conf:/usr/local/etc/isolate:ro
+      - worker-storage:/var/lib/coduels/worker
+
+  taski:
+    image: coduels-taski-e2e:local
+    build:
+      context: ../../Taski
+      dockerfile: Dockerfile
+    command:
+      - /bin/sh
+      - -ec
+      - |
+        mkdir -p /var/lib/coduels/taski/storage
+        cp -a /task-seed/. /var/lib/coduels/taski/storage/
+        exec /app/bin/taski
+    environment:
+      CONFIG_PATH: /config/taski.yml
+    depends_on:
+      taski-postgres:
+        condition: service_healthy
+      coordinator:
+        condition: service_started
+    volumes:
+      - ./config/taski.yml:/config/taski.yml:ro
+      - ../../Taski/tasks/storage:/task-seed:ro
+      - taski-storage:/var/lib/coduels/taski
+
+  test:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    environment:
+      CODUELS_E2E: "1"
+      TASKI_URL: http://taski:5252
+      COORDINATOR_URL: http://coordinator:5253
+    depends_on:
+      taski:
+        condition: service_started
+      worker:
+        condition: service_started
+
+volumes:
+  exesh-postgres:
+  taski-postgres:
+  coordinator-storage:
+  worker-storage:
+  taski-storage:

--- a/e2e/taski-exesh/config/coordinator.yml
+++ b/e2e/taski-exesh/config/coordinator.yml
@@ -1,0 +1,34 @@
+env: docker
+http_server:
+  addr: 0.0.0.0:5253
+  metrics_addr: ""
+storage:
+  connection_string: host=exesh-postgres port=5432 database=exesh user=coordinator password=secret
+  init_timeout: 60s
+filestorage:
+  root_dir: /var/lib/coduels/coordinator
+  trasher:
+    workers: 1
+    collector_iterations_delay: 60
+    worker_iterations_delay: 5
+job_factory:
+  output:
+    compiled_binary: bin
+    run_output: output
+  source_ttl:
+    filestorage_bucket: 30m
+  filestorage_endpoint: http://coordinator:5253
+execution_scheduler:
+  executions_interval: 100ms
+  capacity: 7680000000
+  execution_retry_after: 30s
+job_scheduler:
+  promised_jobs_limit: 5
+  promise_reschedule_interval: 100ms
+worker_pool:
+  worker_die_after: 2s
+dispatcher:
+  kafka_enabled: false
+  brokers: []
+  topic: exesh.step-updates
+  sasl_auth: false

--- a/e2e/taski-exesh/config/taski.yml
+++ b/e2e/taski-exesh/config/taski.yml
@@ -1,0 +1,34 @@
+env: docker
+http_server:
+  addr: 0.0.0.0:5252
+  metrics_addr: ""
+filestorage:
+  root_dir: /var/lib/coduels/taski
+  trasher:
+    workers: 1
+    collector_iterations_delay: 60
+    worker_iterations_delay: 5
+db:
+  connection_string: host=taski-postgres port=5432 database=taski user=taski password=secret
+  init_timeout: 60s
+execute:
+  endpoint: http://coordinator:5253
+  download_task_endpoint: http://taski:5252
+event_consumer:
+  mode: rest
+  brokers: []
+  topic: exesh.step-updates
+  group_id: taski-e2e
+  fetch_interval: 50ms
+  rest_endpoint: http://coordinator:5253
+  poll_interval: 100ms
+  messages_count: 100
+  sasl_auth: false
+message_dispatcher:
+  kafka_enabled: false
+  brokers: []
+  topic: taski.testing
+  sasl_auth: false
+metrics_collector:
+  collect_interval: 5s
+task_topics: []

--- a/e2e/taski-exesh/config/worker.yml
+++ b/e2e/taski-exesh/config/worker.yml
@@ -1,0 +1,23 @@
+env: docker
+runtime: isolate
+http_server:
+  addr: 0.0.0.0:5254
+  metrics_addr: ""
+filestorage:
+  root_dir: /var/lib/coduels/worker
+  trasher:
+    workers: 1
+    collector_iterations_delay: 60
+    worker_iterations_delay: 5
+source_provider:
+  filestorage_bucket_ttl: 15m
+  artifact_ttl: 5m
+output_provider:
+  artifact_ttl: 5m
+worker:
+  id: http://worker:5254
+  free_slots: 2
+  available_memory_mb: 1024
+  coordinator_endpoint: http://coordinator:5253
+  heartbeat_delay: 100ms
+  worker_delay: 10ms

--- a/e2e/taski-exesh/go.mod
+++ b/e2e/taski-exesh/go.mod
@@ -1,0 +1,3 @@
+module coduels/e2e/taski-exesh
+
+go 1.24.0

--- a/e2e/taski-exesh/run.sh
+++ b/e2e/taski-exesh/run.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env sh
+set -eu
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+project_name="coduels-taski-exesh-e2e-$$"
+
+cleanup() {
+  docker compose \
+    --project-name "$project_name" \
+    --file "$script_dir/compose.yml" \
+    down --volumes --remove-orphans
+}
+
+trap cleanup EXIT INT TERM
+
+docker compose \
+  --project-name "$project_name" \
+  --file "$script_dir/compose.yml" \
+  up --build --abort-on-container-exit --exit-code-from test

--- a/e2e/taski-exesh/taski_exesh_test.go
+++ b/e2e/taski-exesh/taski_exesh_test.go
@@ -1,0 +1,344 @@
+package taskiexeshe2e
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	aPlusBTaskID = "7d971f50363cf0aebbd87d971f50363cf0aebbd8"
+	accepted     = "Accepted"
+	finish       = "finish"
+)
+
+var aPlusBSolution = strings.TrimSpace(`
+#include <iostream>
+
+int main() {
+    long long a, b;
+    std::cin >> a >> b;
+    std::cout << a + b << '\n';
+    return 0;
+}
+`) + "\n"
+
+type apiResponse struct {
+	Status string `json:"status"`
+	Error  string `json:"error"`
+}
+
+type messagesResponse struct {
+	apiResponse
+	Messages []storedMessage `json:"messages"`
+}
+
+type storedMessage struct {
+	MessageID int64           `json:"message_id"`
+	Message   json.RawMessage `json:"message"`
+}
+
+type testingMessage struct {
+	SolutionID string `json:"solution_id"`
+	Type       string `json:"type"`
+	Status     string `json:"status"`
+	Verdict    string `json:"verdict"`
+	Error      string `json:"error"`
+	Message    string `json:"message"`
+}
+
+func TestABSolutionAccepted(t *testing.T) {
+	if os.Getenv("CODUELS_E2E") != "1" {
+		t.Skip("run with ./run.sh to start the Taski/Exesh stack")
+	}
+
+	taskiURL := strings.TrimRight(envOrDefault("TASKI_URL", "http://taski:5252"), "/")
+	coordinatorURL := strings.TrimRight(envOrDefault("COORDINATOR_URL", "http://coordinator:5253"), "/")
+	client := &http.Client{Timeout: 10 * time.Second}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	if err := waitForHTTPServer(ctx, client, coordinatorURL); err != nil {
+		t.Fatalf("coordinator did not become ready: %v", err)
+	}
+	if err := waitForStatus(ctx, client, taskiURL+"/task/"+aPlusBTaskID, http.StatusOK); err != nil {
+		t.Fatalf("Taski did not expose the A+B task: %v", err)
+	}
+
+	solutionID, err := randomSolutionID()
+	if err != nil {
+		t.Fatalf("create random solution ID: %v", err)
+	}
+	t.Logf("solution_id=%s", solutionID)
+
+	if err = submitSolution(ctx, client, taskiURL, solutionID); err != nil {
+		t.Fatalf("submit A+B solution: %v", err)
+	}
+
+	last, err := waitForAcceptedFinish(ctx, client, taskiURL, solutionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Re-read the history after the system has settled to prove that Accepted
+	// remains the last Taski message rather than an intermediate observation.
+	select {
+	case <-ctx.Done():
+		t.Fatalf("wait for stable final status: %v", ctx.Err())
+	case <-time.After(time.Second):
+	}
+
+	stableLast, stableMessage, err := fetchLastMessage(ctx, client, taskiURL, solutionID)
+	if err != nil {
+		t.Fatalf("re-read final Taski message: %v", err)
+	}
+	if stableLast.MessageID != last.MessageID || stableMessage.Type != finish || stableMessage.Verdict != accepted {
+		t.Fatalf(
+			"Taski final message changed: first=%s, stable=%s",
+			formatMessage(last, testingMessage{Type: finish, Verdict: accepted}),
+			formatMessage(stableLast, stableMessage),
+		)
+	}
+}
+
+func submitSolution(ctx context.Context, client *http.Client, taskiURL, solutionID string) error {
+	payload := struct {
+		SolutionID string `json:"solution_id"`
+		TaskID     string `json:"task_id"`
+		Solution   string `json:"solution"`
+		Language   string `json:"language"`
+	}{
+		SolutionID: solutionID,
+		TaskID:     aPlusBTaskID,
+		Solution:   aPlusBSolution,
+		Language:   "Cpp",
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, taskiURL+"/test", bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	content, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("read response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("Taski returned status %d: %s", resp.StatusCode, strings.TrimSpace(string(content)))
+	}
+
+	var result apiResponse
+	if err = json.Unmarshal(content, &result); err != nil {
+		return fmt.Errorf("decode response: %w", err)
+	}
+	if result.Status != "OK" {
+		return fmt.Errorf("Taski rejected submission: status=%q error=%q", result.Status, result.Error)
+	}
+
+	return nil
+}
+
+func waitForAcceptedFinish(
+	ctx context.Context,
+	client *http.Client,
+	taskiURL string,
+	solutionID string,
+) (storedMessage, error) {
+	ticker := time.NewTicker(250 * time.Millisecond)
+	defer ticker.Stop()
+
+	var last storedMessage
+	var lastMessage testingMessage
+	for {
+		current, message, err := fetchLastMessage(ctx, client, taskiURL, solutionID)
+		if err == nil && current.MessageID > 0 {
+			last = current
+			lastMessage = message
+			if message.Type == finish {
+				if message.SolutionID != solutionID {
+					return storedMessage{}, fmt.Errorf("final message has solution_id=%q, want %q", message.SolutionID, solutionID)
+				}
+				if message.Verdict != accepted {
+					return storedMessage{}, fmt.Errorf("A+B was not accepted: %s", formatMessage(current, message))
+				}
+				return current, nil
+			}
+		}
+
+		select {
+		case <-ctx.Done():
+			if last.MessageID == 0 {
+				return storedMessage{}, fmt.Errorf("timed out waiting for Taski messages: %w", ctx.Err())
+			}
+			return storedMessage{}, fmt.Errorf(
+				"timed out waiting for Accepted final message; last=%s: %w",
+				formatMessage(last, lastMessage),
+				ctx.Err(),
+			)
+		case <-ticker.C:
+		}
+	}
+}
+
+func fetchLastMessage(
+	ctx context.Context,
+	client *http.Client,
+	taskiURL string,
+	solutionID string,
+) (storedMessage, testingMessage, error) {
+	url := fmt.Sprintf("%s/solutions/%s/messages?start_id=1&count=1000", taskiURL, solutionID)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return storedMessage{}, testingMessage{}, fmt.Errorf("create messages request: %w", err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return storedMessage{}, testingMessage{}, fmt.Errorf("request messages: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		content, readErr := io.ReadAll(resp.Body)
+		if readErr != nil {
+			return storedMessage{}, testingMessage{}, fmt.Errorf("read messages error response: %w", readErr)
+		}
+		return storedMessage{}, testingMessage{}, fmt.Errorf(
+			"messages endpoint returned status %d: %s",
+			resp.StatusCode,
+			strings.TrimSpace(string(content)),
+		)
+	}
+
+	var result messagesResponse
+	if err = json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return storedMessage{}, testingMessage{}, fmt.Errorf("decode messages response: %w", err)
+	}
+	if result.Status != "OK" {
+		return storedMessage{}, testingMessage{}, fmt.Errorf("messages endpoint failed: %s", result.Error)
+	}
+	if len(result.Messages) == 0 {
+		return storedMessage{}, testingMessage{}, nil
+	}
+
+	sort.Slice(result.Messages, func(i, j int) bool {
+		return result.Messages[i].MessageID < result.Messages[j].MessageID
+	})
+	for i := 1; i < len(result.Messages); i++ {
+		if result.Messages[i-1].MessageID == result.Messages[i].MessageID {
+			return storedMessage{}, testingMessage{}, fmt.Errorf("duplicate Taski message_id=%d", result.Messages[i].MessageID)
+		}
+	}
+
+	last := result.Messages[len(result.Messages)-1]
+	var message testingMessage
+	if err = json.Unmarshal(last.Message, &message); err != nil {
+		return storedMessage{}, testingMessage{}, fmt.Errorf("decode Taski message %d: %w", last.MessageID, err)
+	}
+
+	return last, message, nil
+}
+
+func waitForHTTPServer(ctx context.Context, client *http.Client, url string) error {
+	return waitFor(ctx, func() error {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		if err != nil {
+			return err
+		}
+		resp, err := client.Do(req)
+		if err != nil {
+			return err
+		}
+		return resp.Body.Close()
+	})
+}
+
+func waitForStatus(ctx context.Context, client *http.Client, url string, want int) error {
+	return waitFor(ctx, func() error {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		if err != nil {
+			return err
+		}
+		resp, err := client.Do(req)
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != want {
+			return fmt.Errorf("got HTTP %d, want %d", resp.StatusCode, want)
+		}
+		return nil
+	})
+}
+
+func waitFor(ctx context.Context, check func() error) error {
+	ticker := time.NewTicker(250 * time.Millisecond)
+	defer ticker.Stop()
+
+	var lastErr error
+	for {
+		if err := check(); err == nil {
+			return nil
+		} else {
+			lastErr = err
+		}
+
+		select {
+		case <-ctx.Done():
+			return errors.Join(ctx.Err(), lastErr)
+		case <-ticker.C:
+		}
+	}
+}
+
+func randomSolutionID() (string, error) {
+	random := make([]byte, 16)
+	if _, err := rand.Read(random); err != nil {
+		return "", err
+	}
+	return "e2e-" + hex.EncodeToString(random), nil
+}
+
+func envOrDefault(key, fallback string) string {
+	if value := os.Getenv(key); value != "" {
+		return value
+	}
+	return fallback
+}
+
+func formatMessage(stored storedMessage, message testingMessage) string {
+	return fmt.Sprintf(
+		"message_id=%d solution_id=%q type=%q status=%q verdict=%q error=%q message=%q",
+		stored.MessageID,
+		message.SolutionID,
+		message.Type,
+		message.Status,
+		message.Verdict,
+		message.Error,
+		message.Message,
+	)
+}


### PR DESCRIPTION
## What changed

- advances the `filestorage` submodule to the merged `v1.7.0` release
- upgrades Taski and Exesh Go dependencies from `filestorage v1.6.0` to `v1.7.0`
- adds an isolated Docker Compose e2e stack for Taski, Exesh Coordinator/Worker, and PostgreSQL
- submits a correct C++ A+B solution with a random `solution_id`
- polls Taski's REST message history and verifies that the stable last message is `finish` with verdict `Accepted`

## Why

The new filestorage path and archive hardening must be consumed by both execution services. The backend previously had no persisted end-to-end check proving that a real submission traverses Taski → Exesh → `isolate` and returns an accepted terminal status.

The e2e Compose project exposes no host ports and uses no fixed container names, so it can run alongside the regular local CoDuels stack. It cleans up its own containers, network, and volumes after the run.

## Validation

- `go test ./...` in `Taski`
- `go test ./...` in `Exesh`
- `go test ./...` in `filestorage` at tag `v1.7.0`
- `./e2e/taski-exesh/run.sh` — passed with a random solution ID; A+B finished as `Accepted` and remained the last Taski message
