### PR TITLE
fix(delivery): isolate production service ports

### DIFF
--- a/.github/workflows/alloy_pull_request.yml
+++ b/.github/workflows/alloy_pull_request.yml
@@ -2,6 +2,7 @@ name: Alloy
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [master]
     paths:
       - alloy/**
@@ -12,6 +13,7 @@ permissions:
 
 jobs:
   check-template:
+    if: ${{ github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/analyzer_pull_request.yml
+++ b/.github/workflows/analyzer_pull_request.yml
@@ -2,6 +2,7 @@ name: Analyzer
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [master]
     paths:
       - Analyzer/**
@@ -12,6 +13,7 @@ permissions:
 
 jobs:
   check:
+    if: ${{ github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/duely_pull_request.yml
+++ b/.github/workflows/duely_pull_request.yml
@@ -2,13 +2,18 @@ name: Duely
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [master]
     paths:
       - Duely/**
       - .github/workflows/duely_pull_request.yml
 
+permissions:
+  contents: read
+
 jobs:
   unit-tests:
+    if: ${{ github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/.github/workflows/e2e_tests_pull_request.yml
+++ b/.github/workflows/e2e_tests_pull_request.yml
@@ -2,6 +2,7 @@ name: End-to-end tests
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [master]
     paths:
       - Taski/**
@@ -16,6 +17,7 @@ permissions:
 
 jobs:
   taski-exesh-e2e-test:
+    if: ${{ github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:

--- a/.github/workflows/exesh_pull_request.yml
+++ b/.github/workflows/exesh_pull_request.yml
@@ -2,6 +2,7 @@ name: Exesh
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [master]
     paths:
       - Exesh/**
@@ -12,6 +13,7 @@ permissions:
 
 jobs:
   unit-tests:
+    if: ${{ github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/nginx_pull_request.yml
+++ b/.github/workflows/nginx_pull_request.yml
@@ -2,6 +2,7 @@ name: Nginx
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [master]
     paths:
       - nginx/**
@@ -12,6 +13,7 @@ permissions:
 
 jobs:
   check-config:
+    if: ${{ github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/production_network_pull_request.yml
+++ b/.github/workflows/production_network_pull_request.yml
@@ -2,6 +2,7 @@ name: Production network checks
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [master]
     paths:
       - .github/workflows/production_network_pull_request.yml
@@ -28,6 +29,7 @@ concurrency:
 
 jobs:
   validate:
+    if: ${{ github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/production_network_pull_request.yml
+++ b/.github/workflows/production_network_pull_request.yml
@@ -1,0 +1,79 @@
+name: Production network checks
+
+on:
+  pull_request:
+    branches: [master]
+    paths:
+      - .github/workflows/production_network_pull_request.yml
+      - docker-compose.yml
+      - Duely/docker-compose.yml
+      - Duely/ansible/deploy/playbook.yml
+      - Taski/docker-compose.yml
+      - Taski/ansible/deploy/playbook.yml
+      - Exesh/docker-compose.yml
+      - Exesh/ansible/deploy/playbook.yml
+      - Analyzer/docker-compose.yml
+      - Analyzer/ansible/deploy/playbook.yml
+      - e2e/taski-exesh/compose.yml
+      - nginx/**
+      - alloy/**
+      - scripts/verify-production-network.sh
+
+permissions:
+  contents: read
+
+concurrency:
+  group: production-network-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate Compose topology
+        run: |
+          set -euo pipefail
+          docker compose -f docker-compose.yml config --quiet
+          docker compose -f docker-compose.yml -f Duely/docker-compose.yml config --quiet
+          docker compose -f docker-compose.yml -f Taski/docker-compose.yml config --quiet
+          docker compose -f docker-compose.yml -f Exesh/docker-compose.yml config --quiet
+          docker compose -f docker-compose.yml -f Analyzer/docker-compose.yml config --quiet
+          docker compose -f e2e/taski-exesh/compose.yml config --quiet
+
+      - name: Set up Ansible
+        run: python3 -m pip install ansible docker
+
+      - name: Validate deployment playbooks without Vault secrets
+        run: |
+          set -euo pipefail
+          empty_vars="${RUNNER_TEMP}/coduels-empty-vars.yml"
+          touch "$empty_vars"
+
+          for deploy_dir in \
+            Duely/ansible/deploy \
+            Taski/ansible/deploy \
+            Exesh/ansible/deploy \
+            Analyzer/ansible/deploy \
+            nginx/ansible/deploy \
+            alloy/ansible/deploy
+          do
+            ansible-playbook \
+              -i "$deploy_dir/inventory" \
+              "$deploy_dir/playbook.yml" \
+              --syntax-check \
+              --extra-vars="version=syntax-check credentials_file=$empty_vars"
+          done
+
+      - name: Validate Nginx and rollout script
+        run: |
+          set -euo pipefail
+          bash -n scripts/verify-production-network.sh
+          docker run --rm \
+            --add-host duely:127.0.0.1 \
+            --add-host taski:127.0.0.1 \
+            --add-host exesh-dashboard:127.0.0.1 \
+            -v "$GITHUB_WORKSPACE/nginx/nginx.conf:/etc/nginx/nginx.conf:ro" \
+            nginx:1.29.2 nginx -t

--- a/.github/workflows/taski_pull_request.yml
+++ b/.github/workflows/taski_pull_request.yml
@@ -2,6 +2,7 @@ name: Taski
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [master]
     paths:
       - Taski/**
@@ -13,6 +14,7 @@ permissions:
 
 jobs:
   unit-tests:
+    if: ${{ github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@
 
 ## Change rules
 
+- Treat a failed `gh auth status` inside the sandbox as a possible network-isolation failure, not immediate proof of an expired token. Repeat the same check with approved network access before asking the user to log in again; when that check succeeds, keep the existing credentials and run subsequent network-dependent `gh` commands with the same access.
 - Keep handlers/controllers thin. Put orchestration in application/usecase layers and invariants in domain layers.
 - Use Conventional Commits (`type(scope): description`) for every commit and use the same concise, imperative convention for pull-request titles.
 - For EF model changes, add/update migrations and verify migration startup through the Duely migration image.
@@ -53,6 +54,7 @@
 - Taski-Exesh e2e after any Taski or Exesh change: `./e2e/taski-exesh/run.sh` from the Backend repository.
 - filestorage: `cd filestorage && go test ./...`.
 - Analyzer has no committed automated test suite; at minimum syntax-check changed Python and exercise feature/model code relevant to the change. Train both models with `cd Analyzer && python train.py --data-dir data/train` when the feature schema or training code changes.
+- Production network/delivery changes: validate every Compose combination, syntax-check all deploy playbooks with an empty `credentials_file`, run `bash -n scripts/verify-production-network.sh`, and match `.github/workflows/production_network_pull_request.yml`.
 - Use the matching GitHub Actions workflow as the final CI command reference.
 
 ## Distributed execution process documentation

--- a/Analyzer/ansible/deploy/playbook.yml
+++ b/Analyzer/ansible/deploy/playbook.yml
@@ -19,10 +19,26 @@
         recreate: yes
         restart: yes
         restart_policy: unless-stopped
+        state: healthy
+        healthy_wait_timeout: 120
+        healthcheck:
+          test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/health', timeout=2)"]
+          interval: 5s
+          timeout: 3s
+          retries: 12
+          start_period: 20s
         env:
           ANALYZER_PROD_MODEL_PATH: /app/artifacts/prod_random_forest.pkl
           ANALYZER_BASELINE_MODEL_PATH: /app/artifacts/baseline_logreg.pkl
-        ports:
-          - "8000:8000"
         networks:
           - name: coduels
+    - name: Inspect analyzer rollout
+      docker_container_info:
+        name: analyzer
+      register: analyzer_container
+    - name: Verify analyzer is healthy and private
+      assert:
+        that:
+          - analyzer_container.container.State.Health.Status == "healthy"
+          - (analyzer_container.container.HostConfig.PortBindings | default({}, true) | length) == 0
+          - "'coduels' in analyzer_container.container.NetworkSettings.Networks"

--- a/Analyzer/docker-compose.yml
+++ b/Analyzer/docker-compose.yml
@@ -16,4 +16,10 @@ services:
     networks:
       - coduels
     ports:
-      - "8000:8000"
+      - "127.0.0.1:8000:8000"
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/health', timeout=2)"]
+      interval: 5s
+      timeout: 3s
+      retries: 12
+      start_period: 20s

--- a/Duely/ansible/deploy/playbook.yml
+++ b/Duely/ansible/deploy/playbook.yml
@@ -1,7 +1,7 @@
 - name: Deploy
   hosts: Production
   vars_files:
-    - credentials.yml
+    - "{{ credentials_file | default('credentials.yml') }}"
   remote_user: root
   tasks:
     - name: Ensure network exists
@@ -46,8 +46,14 @@
         recreate: yes
         restart: yes
         restart_policy: unless-stopped
-        ports:
-          - "5001:5001"
+        state: healthy
+        healthy_wait_timeout: 120
+        healthcheck:
+          test: ["CMD-SHELL", "bash -c '</dev/tcp/127.0.0.1/5001'"]
+          interval: 5s
+          timeout: 3s
+          retries: 12
+          start_period: 20s
         env:
           ASPNETCORE_ENVIRONMENT: "Production"
           DbConnection__ConnectionString: "{{ postgres_connection }}"
@@ -59,3 +65,13 @@
           Kafka__GroupId: taski.testing-group
         networks:
           - name: coduels
+    - name: Inspect duely rollout
+      docker_container_info:
+        name: duely
+      register: duely_container
+    - name: Verify duely is healthy and private
+      assert:
+        that:
+          - duely_container.container.State.Health.Status == "healthy"
+          - (duely_container.container.HostConfig.PortBindings | default({}, true) | length) == 0
+          - "'coduels' in duely_container.container.NetworkSettings.Networks"

--- a/Duely/docker-compose.yml
+++ b/Duely/docker-compose.yml
@@ -14,15 +14,15 @@ services:
     networks:
       - coduels
     ports:
-      - "5432:5432"
+      - "127.0.0.1:5432:5432"
     environment:
       POSTGRES_DB: duely
       POSTGRES_USER: duely
       POSTGRES_PASSWORD: secret
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U duely"]
+      test: ["CMD-SHELL", "pg_isready -U duely -d duely && test \"$$(head -1 $$PGDATA/postmaster.pid)\" = \"1\""]
       interval: 1s
-      timeout: 0s
+      timeout: 3s
       retries: 30
     volumes:
       - postgres:/var/lib/postgresql/data
@@ -55,7 +55,13 @@ services:
     networks:
       - coduels
     ports:
-      - "5001:5001"
+      - "127.0.0.1:5001:5001"
+    healthcheck:
+      test: ["CMD-SHELL", "bash -c '</dev/tcp/127.0.0.1/5001'"]
+      interval: 5s
+      timeout: 3s
+      retries: 12
+      start_period: 20s
     environment:
       ASPNETCORE_ENVIRONMENT: Development
       DbConnection__ConnectionString: Server=duely_postgres:5432;Database=duely;Username=duely;Password=secret

--- a/Duely/src/Duely.Infrastructure.Api.Http/WebApplicationExtensions.cs
+++ b/Duely/src/Duely.Infrastructure.Api.Http/WebApplicationExtensions.cs
@@ -21,6 +21,7 @@ public static class WebApplicationExtensions
 
         app.UseCors("AllowAll");
 
+        app.MapGet("/health", () => Results.Ok(new { status = "ok" }));
         app.MapControllers();
     }
 }

--- a/Exesh/ansible/deploy/playbook.yml
+++ b/Exesh/ansible/deploy/playbook.yml
@@ -1,7 +1,7 @@
 - name: Deploy
   hosts: Production
   vars_files:
-    - credentials.yml
+    - "{{ credentials_file | default('credentials.yml') }}"
   remote_user: root
   tasks:
     - name: Ensure network exists
@@ -27,9 +27,14 @@
         recreate: yes
         restart: yes
         restart_policy: unless-stopped
-        ports:
-          - "5253:5253"
-          - "9080:9090"
+        state: healthy
+        healthy_wait_timeout: 120
+        healthcheck:
+          test: ["CMD-SHELL", "bash -c '</dev/tcp/127.0.0.1/5253'"]
+          interval: 5s
+          timeout: 3s
+          retries: 12
+          start_period: 10s
         command:
           - /app/bin/coordinator
         env:
@@ -53,9 +58,14 @@
         recreate: yes
         restart: yes
         restart_policy: unless-stopped
-        ports:
-          - "5254:5254"
-          - "9081:9091"
+        state: healthy
+        healthy_wait_timeout: 120
+        healthcheck:
+          test: ["CMD-SHELL", "bash -c '</dev/tcp/127.0.0.1/5254'"]
+          interval: 5s
+          timeout: 3s
+          retries: 12
+          start_period: 10s
         command:
           - /app/bin/worker
         privileged: true
@@ -78,9 +88,14 @@
         recreate: yes
         restart: yes
         restart_policy: unless-stopped
-        ports:
-          - "5255:5255"
-          - "9082:9092"
+        state: healthy
+        healthy_wait_timeout: 120
+        healthcheck:
+          test: ["CMD-SHELL", "bash -c '</dev/tcp/127.0.0.1/5255'"]
+          interval: 5s
+          timeout: 3s
+          retries: 12
+          start_period: 10s
         command:
           - /app/bin/worker
         privileged: true
@@ -103,9 +118,33 @@
         recreate: yes
         restart: yes
         restart_policy: unless-stopped
-        ports:
-          - "9000:9000"
+        state: healthy
+        healthy_wait_timeout: 120
+        healthcheck:
+          test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:9000/health', timeout=2)"]
+          interval: 5s
+          timeout: 3s
+          retries: 12
+          start_period: 10s
         env:
           EXESH_DASHBOARD_DB_CONNECTION_STRING: "{{ dashboard_postgres_connection }}"
         networks:
           - name: coduels
+    - name: Inspect Exesh rollout
+      docker_container_info:
+        name: "{{ item }}"
+      loop:
+        - coordinator
+        - worker-1
+        - worker-2
+        - exesh-dashboard
+      register: exesh_containers
+    - name: Verify Exesh containers are healthy and private
+      assert:
+        that:
+          - item.container.State.Health.Status == "healthy"
+          - (item.container.HostConfig.PortBindings | default({}, true) | length) == 0
+          - "'coduels' in item.container.NetworkSettings.Networks"
+      loop: "{{ exesh_containers.results }}"
+      loop_control:
+        label: "{{ item.container.Name }}"

--- a/Exesh/cmd/coordinator/main.go
+++ b/Exesh/cmd/coordinator/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	executeAPI "exesh/internal/api/execute"
+	healthAPI "exesh/internal/api/health"
 	heartbeatAPI "exesh/internal/api/heartbeat"
 	messagesAPI "exesh/internal/api/messages"
 	"exesh/internal/calculator"
@@ -49,6 +50,7 @@ func main() {
 	log.Debug("debug messages are enabled")
 
 	mux := chi.NewRouter()
+	healthAPI.Register(mux)
 
 	unitOfWork, executionStorage, outboxStorage, messageStorage, categoryHistogramStorage, eventStorage, err := setupStorage(log, cfg.Storage)
 	if err != nil {

--- a/Exesh/cmd/worker/main.go
+++ b/Exesh/cmd/worker/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"errors"
+	healthAPI "exesh/internal/api/health"
 	"exesh/internal/config"
 	"exesh/internal/domain/execution/job"
 	"exesh/internal/executor"
@@ -47,6 +48,7 @@ func main() {
 	log.Debug("debug messages are enabled")
 
 	mux := chi.NewRouter()
+	healthAPI.Register(mux)
 
 	fs, err := filestorage.New(log, cfg.FileStorage.ToExternal(), mux)
 	if err != nil {

--- a/Exesh/dashboard/config/urls.py
+++ b/Exesh/dashboard/config/urls.py
@@ -4,5 +4,6 @@ from dashboard import views
 
 
 urlpatterns = [
+    path("health", views.health, name="health"),
     path("", views.index, name="index"),
 ]

--- a/Exesh/dashboard/dashboard/views.py
+++ b/Exesh/dashboard/dashboard/views.py
@@ -1,10 +1,15 @@
 from datetime import timedelta
 
+from django.http import JsonResponse
 from django.shortcuts import render
 from django.utils import timezone
 from django.utils.dateparse import parse_datetime
 
 from .chart_rendering import rendered_dashboard
+
+
+def health(_request):
+    return JsonResponse({"status": "ok"})
 
 
 def index(request):

--- a/Exesh/docker-compose.yml
+++ b/Exesh/docker-compose.yml
@@ -14,15 +14,15 @@ services:
     networks:
       - coduels
     ports:
-      - "5433:5432"
+      - "127.0.0.1:5433:5432"
     environment:
       POSTGRES_USER: coordinator
       POSTGRES_PASSWORD: secret
       POSTGRES_DB: exesh
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U coordinator"]
+      test: ["CMD-SHELL", "pg_isready -U coordinator -d exesh && test \"$$(head -1 $$PGDATA/postmaster.pid)\" = \"1\""]
       interval: 1s
-      timeout: 0s
+      timeout: 3s
       retries: 30
     volumes:
       - postgres:/var/lib/postgresql/data
@@ -37,8 +37,14 @@ services:
     networks:
       - coduels
     ports:
-      - "5253:5253"
-      - "9080:9090"
+      - "127.0.0.1:5253:5253"
+      - "127.0.0.1:9080:9090"
+    healthcheck:
+      test: ["CMD-SHELL", "bash -c '</dev/tcp/127.0.0.1/5253'"]
+      interval: 5s
+      timeout: 3s
+      retries: 12
+      start_period: 10s
     environment:
       CONFIG_PATH: /config/coordinator.yml
       ENV: docker
@@ -61,8 +67,14 @@ services:
     networks:
       - coduels
     ports:
-      - "5254:5254"
-      - "9081:9091"
+      - "127.0.0.1:5254:5254"
+      - "127.0.0.1:9081:9091"
+    healthcheck:
+      test: ["CMD-SHELL", "bash -c '</dev/tcp/127.0.0.1/5254'"]
+      interval: 5s
+      timeout: 3s
+      retries: 12
+      start_period: 10s
     environment:
       CONFIG_PATH: /config/worker.yml
       ENV: docker
@@ -87,8 +99,14 @@ services:
     networks:
       - coduels
     ports:
-      - "5255:5255"
-      - "9082:9092"
+      - "127.0.0.1:5255:5255"
+      - "127.0.0.1:9082:9092"
+    healthcheck:
+      test: ["CMD-SHELL", "bash -c '</dev/tcp/127.0.0.1/5255'"]
+      interval: 5s
+      timeout: 3s
+      retries: 12
+      start_period: 10s
     environment:
       CONFIG_PATH: /config/worker.yml
       ENV: docker
@@ -111,7 +129,13 @@ services:
     networks:
       - coduels
     ports:
-      - "9000:9000"
+      - "127.0.0.1:9000:9000"
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:9000/health', timeout=2)"]
+      interval: 5s
+      timeout: 3s
+      retries: 12
+      start_period: 10s
     environment:
       EXESH_DASHBOARD_DB_HOST: exesh_postgres
       EXESH_DASHBOARD_DB_PORT: "5432"

--- a/Exesh/internal/api/health/handler.go
+++ b/Exesh/internal/api/health/handler.go
@@ -1,0 +1,21 @@
+package health
+
+import (
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/render"
+)
+
+type Response struct {
+	Status string `json:"status"`
+}
+
+func Register(r chi.Router) {
+	r.Get("/health", Handle)
+}
+
+func Handle(w http.ResponseWriter, r *http.Request) {
+	render.Status(r, http.StatusOK)
+	render.JSON(w, r, Response{Status: "ok"})
+}

--- a/Exesh/internal/api/health/handler_test.go
+++ b/Exesh/internal/api/health/handler_test.go
@@ -1,0 +1,30 @@
+package health
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func TestHandle(t *testing.T) {
+	router := chi.NewRouter()
+	Register(router)
+
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/health", nil))
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, recorder.Code)
+	}
+
+	var response Response
+	if err := json.NewDecoder(recorder.Body).Decode(&response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.Status != "ok" {
+		t.Fatalf("expected health status ok, got %q", response.Status)
+	}
+}

--- a/Taski/ansible/deploy/playbook.yml
+++ b/Taski/ansible/deploy/playbook.yml
@@ -1,7 +1,7 @@
 - name: Deploy
   hosts: Production
   vars_files:
-    - credentials.yml
+    - "{{ credentials_file | default('credentials.yml') }}"
   vars:
     tasks_dir: "{{ ansible_env.HOME }}/tasks"
   remote_user: root
@@ -28,9 +28,14 @@
         recreate: yes
         restart: yes
         restart_policy: unless-stopped
-        ports:
-          - "5252:5252"
-          - "9077:9090"
+        state: healthy
+        healthy_wait_timeout: 120
+        healthcheck:
+          test: ["CMD-SHELL", "bash -c '</dev/tcp/127.0.0.1/5252'"]
+          interval: 5s
+          timeout: 3s
+          retries: 12
+          start_period: 10s
         env:
           ENV: prod
           CONFIG_PATH: /app/config/taski.yml
@@ -54,3 +59,13 @@
           - "{{ tasks_dir }}/storage:/app/file_storage/storage"
         networks:
           - name: coduels
+    - name: Inspect taski rollout
+      docker_container_info:
+        name: taski
+      register: taski_container
+    - name: Verify taski is healthy and private
+      assert:
+        that:
+          - taski_container.container.State.Health.Status == "healthy"
+          - (taski_container.container.HostConfig.PortBindings | default({}, true) | length) == 0
+          - "'coduels' in taski_container.container.NetworkSettings.Networks"

--- a/Taski/cmd/taski/main.go
+++ b/Taski/cmd/taski/main.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	healthAPI "taski/internal/api/health"
 	getFileAPI "taski/internal/api/task/file"
 	getAPI "taski/internal/api/task/get"
 	listAPI "taski/internal/api/task/list"
@@ -69,6 +70,7 @@ func main() {
 		AllowCredentials: false,
 		MaxAge:           300,
 	}))
+	healthAPI.Register(mux)
 
 	fileStorage, err := fs.New(log, cfg.FileStorage, mux)
 	if err != nil {

--- a/Taski/docker-compose.yml
+++ b/Taski/docker-compose.yml
@@ -14,15 +14,15 @@ services:
     networks:
       - coduels
     ports:
-      - "5434:5432"
+      - "127.0.0.1:5434:5432"
     environment:
       POSTGRES_USER: taski
       POSTGRES_PASSWORD: secret
       POSTGRES_DB: taski
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U taski"]
+      test: ["CMD-SHELL", "pg_isready -U taski -d taski && test \"$$(head -1 $$PGDATA/postmaster.pid)\" = \"1\""]
       interval: 1s
-      timeout: 0s
+      timeout: 3s
       retries: 30
     volumes:
       - postgres:/var/lib/postgresql/data
@@ -33,8 +33,14 @@ services:
     networks:
       - coduels
     ports:
-      - "5252:5252"
-      - "9077:9090"
+      - "127.0.0.1:5252:5252"
+      - "127.0.0.1:9077:9090"
+    healthcheck:
+      test: ["CMD-SHELL", "bash -c '</dev/tcp/127.0.0.1/5252'"]
+      interval: 5s
+      timeout: 3s
+      retries: 12
+      start_period: 10s
     environment:
       CONFIG_PATH: /config/taski.yml
       ENV: docker

--- a/Taski/internal/api/health/handler.go
+++ b/Taski/internal/api/health/handler.go
@@ -1,0 +1,21 @@
+package health
+
+import (
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/render"
+)
+
+type Response struct {
+	Status string `json:"status"`
+}
+
+func Register(r chi.Router) {
+	r.Get("/health", Handle)
+}
+
+func Handle(w http.ResponseWriter, r *http.Request) {
+	render.Status(r, http.StatusOK)
+	render.JSON(w, r, Response{Status: "ok"})
+}

--- a/Taski/internal/api/health/handler_test.go
+++ b/Taski/internal/api/health/handler_test.go
@@ -1,0 +1,30 @@
+package health
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func TestHandle(t *testing.T) {
+	router := chi.NewRouter()
+	Register(router)
+
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/health", nil))
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, recorder.Code)
+	}
+
+	var response Response
+	if err := json.NewDecoder(recorder.Body).Decode(&response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.Status != "ok" {
+		t.Fatalf("expected health status ok, got %q", response.Status)
+	}
+}

--- a/alloy/ansible/deploy/playbook.yml
+++ b/alloy/ansible/deploy/playbook.yml
@@ -1,7 +1,7 @@
 - name: Deploy Grafana Alloy
   hosts: Production
   vars_files:
-    - credentials.yml
+    - "{{ credentials_file | default('credentials.yml') }}"
   vars:
     grafana_prometheus_remote_write_url: https://prometheus-prod-56-prod-us-east-2.grafana.net/api/prom/push
     grafana_loki_push_url: https://logs-prod-036.grafana.net/loki/api/v1/push
@@ -46,11 +46,27 @@
         restart: yes
         restart_policy: unless-stopped
         command: run --server.http.listen-addr=0.0.0.0:12345 --storage.path=/var/lib/alloy/data /etc/alloy/config.alloy
-        ports:
-          - "12345:12345"
         volumes:
           - "/opt/coduels/alloy/config.alloy:/etc/alloy/config.alloy:ro"
           - "/var/lib/coduels/alloy:/var/lib/alloy/data"
           - "/var/run/docker.sock:/var/run/docker.sock"
         networks:
           - name: coduels
+    - name: Inspect Alloy rollout
+      docker_container_info:
+        name: alloy
+      register: alloy_container
+    - name: Verify Alloy is private and networked
+      assert:
+        that:
+          - alloy_container.container.State.Running
+          - (alloy_container.container.HostConfig.PortBindings | default({}, true) | length) == 0
+          - "'coduels' in alloy_container.container.NetworkSettings.Networks"
+    - name: Wait for Alloy readiness through the Docker network
+      uri:
+        url: "http://{{ alloy_container.container.NetworkSettings.Networks.coduels.IPAddress }}:12345/-/ready"
+        status_code: 200
+      register: alloy_health
+      retries: 12
+      delay: 5
+      until: alloy_health.status == 200

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     networks:
       - coduels
     ports:
-      - "2181:2181"
+      - "127.0.0.1:2181:2181"
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
   kafka:
@@ -19,8 +19,8 @@ services:
     networks:
       - coduels
     ports:
-      - "9092:9092"
-      - "29092:29092"
+      - "127.0.0.1:9092:9092"
+      - "127.0.0.1:29092:29092"
     environment:
       KAFKA_BROKER_ID: 1
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
@@ -51,7 +51,7 @@ services:
     networks:
       - coduels
     ports:
-      - "8080:8080"
+      - "127.0.0.1:8080:8080"
     environment:
       KAFKA_CLUSTERS_0_NAME: local
       KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: kafka:9092

--- a/docs/processes/README.md
+++ b/docs/processes/README.md
@@ -107,5 +107,6 @@ a pending transition or recipient changes.
 
 ## Other component process documentation
 
+- [Production network topology and rollout checks](../production-network.md)
 - [Exesh distributed execution processes](exesh/README.md)
 - [Taski task and testing processes](taski/README.md)

--- a/docs/production-network.md
+++ b/docs/production-network.md
@@ -1,0 +1,73 @@
+# Production network topology
+
+Production containers share the external Docker bridge network `coduels` and
+address each other by container DNS name. Only Nginx publishes host ports: 80
+and 443. Application APIs, dashboards, metrics, databases, and Alloy remain
+reachable only inside the Docker network.
+
+Local Compose files preserve developer access by binding internal ports to
+`127.0.0.1`. These loopback bindings are development-only and must not be
+copied into production playbooks.
+
+## Connection matrix
+
+| Caller | Destination | Port/path | Purpose |
+| --- | --- | --- | --- |
+| Browser/client | Nginx | host 80/443 | Public HTTP/WebSocket entrypoint |
+| Nginx | Duely | `duely:5001` | Public Duely API, WebSocket, Swagger |
+| Nginx | Taski | `taski:5252/task/*` | Public task metadata and files |
+| Nginx | Exesh dashboard | `exesh-dashboard:9000` | Dashboard proxy |
+| Duely | Taski | `taski:5252` | Start tests and poll solution messages |
+| Duely | Coordinator | `coordinator:5253` | Code runs and execution messages |
+| Duely | Analyzer | `analyzer:8000` | Post-duel suspicion scoring |
+| Taski | Coordinator | `coordinator:5253` | Submit executions and poll messages |
+| Coordinator | workers | `worker-1:5254`, `worker-2:5255` | Artifact transfer and scheduled jobs |
+| Workers | Coordinator | `coordinator:5253/heartbeat` | Capacity, job requests, and results |
+| Alloy | Duely | `duely:5001/metrics` | Prometheus scrape |
+| Alloy | Taski | `taski:9090/` | Prometheus scrape |
+| Alloy | Coordinator | `coordinator:9090/` | Prometheus scrape |
+| Alloy | workers | `worker-1:9091/`, `worker-2:9092/` | Prometheus scrape |
+| Alloy | Grafana Cloud | HTTPS | Metrics remote write and log shipping |
+
+The health endpoints are `/health` on Duely, Taski, Coordinator, workers,
+Analyzer, and the Exesh dashboard. Nginx exposes its own `/health`; Alloy uses
+`/-/ready`. Health endpoints report process readiness and are not substitutes
+for authenticated business APIs.
+
+## Rollout verification
+
+Run the check from a trusted shell on the target host after a deployment:
+
+```sh
+CODUELS_EXPECTED_VERSION=<root-merge-sha> ./scripts/verify-production-network.sh
+```
+
+The script verifies that every expected container is attached to `coduels`,
+only Nginx publishes host ports, internal health and metrics endpoints resolve
+through Docker DNS, public Nginx routes work, and the old direct host ports do
+not answer on loopback. Confirm in Grafana that fresh samples arrive after at
+least two scrape intervals; local readiness cannot prove remote-write receipt.
+
+The `Production network checks` pull-request workflow validates every Compose
+combination, all deployment playbooks with an empty syntax-only vars file, the
+Nginx configuration, and the rollout script. It never decrypts Vault files or
+contacts a production inventory.
+
+Run the same script from an external test machine against the deployment host
+or verify the firewall separately when testing the external perimeter. Docker
+port inspection proves that these playbooks do not publish internal ports, but
+it does not audit unrelated host firewall or process configuration.
+
+## Rollback verification
+
+Redeploy the last known-good root merge SHA through the approved root release
+workflow or the same component playbooks used by that workflow. Do not run a
+production playbook ad hoc. After rollback, rerun:
+
+```sh
+CODUELS_EXPECTED_VERSION=<last-known-good-root-sha> ./scripts/verify-production-network.sh
+```
+
+Rollback is complete only when the previous images are running, all readiness
+and route checks pass, no internal host ports are published, and Grafana again
+receives current samples.

--- a/e2e/taski-exesh/README.md
+++ b/e2e/taski-exesh/README.md
@@ -21,7 +21,8 @@ Run it from the Backend repository:
 
 The Compose project uses no host ports or fixed container names, so it can run
 alongside the regular local CoDuels stack. Containers, networks, and volumes
-created by the test are removed when it finishes.
+created by the test are removed when it finishes. Taski, Coordinator, and the
+worker must pass their container health checks before the test client starts.
 
 The `End-to-end tests` pull-request workflow in
 `.github/workflows/e2e_tests_pull_request.yml` runs this command once when a PR

--- a/e2e/taski-exesh/compose.yml
+++ b/e2e/taski-exesh/compose.yml
@@ -6,7 +6,7 @@ services:
       POSTGRES_PASSWORD: secret
       POSTGRES_DB: exesh
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U coordinator -d exesh"]
+      test: ["CMD-SHELL", "pg_isready -U coordinator -d exesh && test \"$$(head -1 $$PGDATA/postmaster.pid)\" = \"1\""]
       interval: 1s
       timeout: 3s
       retries: 60
@@ -20,7 +20,7 @@ services:
       POSTGRES_PASSWORD: secret
       POSTGRES_DB: taski
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U taski -d taski"]
+      test: ["CMD-SHELL", "pg_isready -U taski -d taski && test \"$$(head -1 $$PGDATA/postmaster.pid)\" = \"1\""]
       interval: 1s
       timeout: 3s
       retries: 60
@@ -38,6 +38,11 @@ services:
     depends_on:
       exesh-postgres:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "bash -c '</dev/tcp/127.0.0.1/5253'"]
+      interval: 2s
+      timeout: 2s
+      retries: 30
     volumes:
       - ./config/coordinator.yml:/config/coordinator.yml:ro
 
@@ -51,7 +56,12 @@ services:
       CONFIG_PATH: /config/worker.yml
     depends_on:
       coordinator:
-        condition: service_started
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "bash -c '</dev/tcp/127.0.0.1/5254'"]
+      interval: 2s
+      timeout: 2s
+      retries: 30
     privileged: true
     volumes:
       - ./config/worker.yml:/config/worker.yml:ro
@@ -75,7 +85,12 @@ services:
       taski-postgres:
         condition: service_healthy
       coordinator:
-        condition: service_started
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "bash -c '</dev/tcp/127.0.0.1/5252'"]
+      interval: 2s
+      timeout: 2s
+      retries: 30
     volumes:
       - ./config/taski.yml:/config/taski.yml:ro
       - ../../Taski/tasks/storage:/task-seed:ro
@@ -91,9 +106,9 @@ services:
       COORDINATOR_URL: http://coordinator:5253
     depends_on:
       taski:
-        condition: service_started
+        condition: service_healthy
       worker:
-        condition: service_started
+        condition: service_healthy
 
 volumes:
   exesh-postgres:

--- a/nginx/ansible/deploy/playbook.yml
+++ b/nginx/ansible/deploy/playbook.yml
@@ -23,6 +23,13 @@
         recreate: yes
         restart: yes
         restart_policy: unless-stopped
+        state: healthy
+        healthy_wait_timeout: 60
+        healthcheck:
+          test: ["CMD-SHELL", "nginx -t"]
+          interval: 5s
+          timeout: 3s
+          retries: 6
         ports:
           - "80:80"
           - "443:443"
@@ -30,3 +37,22 @@
           - /opt/coduels/nginx/nginx.conf:/etc/nginx/nginx.conf:ro
         networks:
           - name: coduels
+    - name: Wait for public nginx readiness
+      uri:
+        url: http://127.0.0.1/health
+        status_code: 200
+        return_content: true
+      register: nginx_health
+      retries: 12
+      delay: 5
+      until: nginx_health.status == 200
+    - name: Inspect nginx rollout
+      docker_container_info:
+        name: nginx
+      register: nginx_container
+    - name: Verify nginx publishes only public entrypoints
+      assert:
+        that:
+          - nginx_container.container.State.Health.Status == "healthy"
+          - "'coduels' in nginx_container.container.NetworkSettings.Networks"
+          - (nginx_container.container.HostConfig.PortBindings | dict2items | map(attribute='key') | sort) == ['443/tcp', '80/tcp']

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,5 +1,10 @@
 http {
   server {
+    location = /health {
+      access_log off;
+      default_type text/plain;
+      return 200 "ok\n";
+    }
     location /api/swagger {
       proxy_pass http://duely:5001/swagger;
     }

--- a/scripts/verify-production-network.sh
+++ b/scripts/verify-production-network.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+network="${CODUELS_NETWORK:-coduels}"
+probe_image="${CODUELS_PROBE_IMAGE:-curlimages/curl:8.12.1}"
+public_url="${CODUELS_PUBLIC_URL:-http://127.0.0.1}"
+expected_version="${CODUELS_EXPECTED_VERSION:-}"
+
+private_containers=(
+  duely
+  taski
+  coordinator
+  worker-1
+  worker-2
+  analyzer
+  exesh-dashboard
+  alloy
+)
+all_containers=("${private_containers[@]}" nginx)
+
+fail() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+command -v docker >/dev/null || fail "docker is required"
+command -v curl >/dev/null || fail "curl is required"
+docker network inspect "$network" >/dev/null 2>&1 || fail "Docker network '$network' does not exist"
+
+for container in "${all_containers[@]}"; do
+  docker inspect "$container" >/dev/null 2>&1 || fail "container '$container' is missing"
+  container_ip="$(docker inspect --format "{{with index .NetworkSettings.Networks \"$network\"}}{{.IPAddress}}{{end}}" "$container")"
+  [[ -n "$container_ip" ]] || fail "container '$container' is not attached to '$network'"
+done
+
+for container in "${private_containers[@]}"; do
+  published="$(docker inspect --format '{{range $port, $bindings := .NetworkSettings.Ports}}{{if $bindings}}{{$port}} {{end}}{{end}}' "$container")"
+  [[ -z "$published" ]] || fail "container '$container' publishes internal ports: $published"
+done
+
+nginx_ports="$(docker inspect --format '{{range $port, $bindings := .NetworkSettings.Ports}}{{if $bindings}}{{$port}}{{"\n"}}{{end}}{{end}}' nginx | sort | xargs)"
+[[ "$nginx_ports" == "443/tcp 80/tcp" ]] || fail "nginx publishes unexpected ports: ${nginx_ports:-none}"
+
+if [[ -n "$expected_version" ]]; then
+  for container in duely taski coordinator worker-1 worker-2 analyzer exesh-dashboard; do
+    image="$(docker inspect --format '{{.Config.Image}}' "$container")"
+    [[ "$image" == *":$expected_version" ]] || fail "container '$container' uses '$image', expected tag '$expected_version'"
+  done
+fi
+
+probe() {
+  local url="$1"
+  docker run --rm --network "$network" "$probe_image" \
+    --fail --silent --show-error --max-time 5 "$url" >/dev/null
+}
+
+probe http://duely:5001/health
+probe http://taski:5252/health
+probe http://coordinator:5253/health
+probe http://worker-1:5254/health
+probe http://worker-2:5255/health
+probe http://analyzer:8000/health
+probe http://exesh-dashboard:9000/health
+probe http://alloy:12345/-/ready
+probe http://duely:5001/metrics
+probe http://taski:9090/
+probe http://coordinator:9090/
+probe http://worker-1:9091/
+probe http://worker-2:9092/
+
+public_url="${public_url%/}"
+curl --fail --silent --show-error --max-time 5 "$public_url/health" >/dev/null
+curl --fail --silent --show-error --max-time 5 "$public_url/api/swagger/index.html" >/dev/null
+curl --fail --silent --show-error --max-time 5 "$public_url/api/task/topics" >/dev/null
+curl --fail --silent --show-error --max-time 5 "$public_url/exesh-dashboard/health" >/dev/null
+
+for port in 5001 5252 5253 5254 5255 8000 9000 9077 9080 9081 9082 12345; do
+  if curl --silent --output /dev/null --connect-timeout 1 --max-time 1 "http://127.0.0.1:$port/"; then
+    fail "internal host port '$port' accepts HTTP connections"
+  fi
+done
+
+echo "Production network verification passed."


### PR DESCRIPTION
## Summary

- remove production host port publishing from Duely, Taski, Exesh, Analyzer, dashboard, metrics, and Alloy while keeping all containers on the `coduels` Docker network
- bind local-development internal ports to loopback only
- add `/health` endpoints, Docker health checks, deployment readiness assertions, and hardened PostgreSQL readiness
- preserve Alloy scraping through Docker DNS and verify all scrape targets without host ports
- document the production connection matrix and add a rollout/rollback verifier
- add a PR workflow for Compose, Ansible, Nginx, and rollout-script validation without decrypting Vault files

## Why

Production playbooks exposed unauthenticated internal APIs and metrics on host interfaces. A firewall mistake could allow callers to bypass Nginx and submit or manipulate internal execution work directly.

## Impact

Only Nginx publishes production host ports (80/443). Internal callers continue to use service DNS on `coduels`. Local Compose access remains available on `127.0.0.1` for development.

## Validation

- `go test ./...` in Taski
- `go test ./...` in Exesh
- `dotnet test --configuration Release` in Duely (400 tests)
- `python manage.py check` for Exesh Dashboard
- Analyzer Python syntax compilation
- all six Compose configurations via `docker compose config --quiet`
- all six deployment playbooks via `ansible-playbook --syntax-check` with an empty syntax-only vars file
- Nginx 1.29.2 configuration check
- `bash -n scripts/verify-production-network.sh`
- `./e2e/taski-exesh/run.sh` with the privileged worker and `isolate`

Closes #281

First stage of DIvanCode/CoDuels#94.