### PR TITLE
feat(duely): expose task level rating ranges

### DIFF
--- a/Duely/src/Duely.Domain.Services/Duels/RatingManager.cs
+++ b/Duely/src/Duely.Domain.Services/Duels/RatingManager.cs
@@ -7,6 +7,7 @@ public interface IRatingManager
     void UpdateRatings(Duel duel);
     Dictionary<DuelResult, int> GetRatingChanges(Duel duel, int rating, int anotherRating);
     int GetTaskLevel(int rating);
+    IReadOnlyDictionary<int, string> GetTaskLevelRatingRanges();
 }
 public sealed class RatingManager(IOptions<DuelOptions> options) : IRatingManager
 {
@@ -76,6 +77,12 @@ public sealed class RatingManager(IOptions<DuelOptions> options) : IRatingManage
             .Select(item => item.Level)
             .SingleOrDefault();
         return bestLevel == default ? 1 : bestLevel;
+    }
+
+    public IReadOnlyDictionary<int, string> GetTaskLevelRatingRanges()
+    {
+        return options.Value.RatingToTaskLevelMapping
+            .ToDictionary(item => item.Level, item => item.Rating);
     }
     
     private static int GetK(int rating)

--- a/Duely/src/Duely.Infrastructure.Api.Http/Controllers/DuelsController.cs
+++ b/Duely/src/Duely.Infrastructure.Api.Http/Controllers/DuelsController.cs
@@ -1,6 +1,7 @@
 using Duely.Application.UseCases.Dtos;
 using Duely.Application.UseCases.Features.Duels;
 using Duely.Application.UseCases.Features.Duels.Search;
+using Duely.Domain.Services.Duels;
 using Duely.Infrastructure.Api.Http.Services;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
@@ -13,8 +14,15 @@ namespace Duely.Infrastructure.Api.Http.Controllers;
 [Authorize]
 public sealed class DuelsController(
     IMediator mediator,
-    IUserContext userContext) : ControllerBase
+    IUserContext userContext,
+    IRatingManager ratingManager) : ControllerBase
 {
+    [HttpGet("task-level-rating-ranges")]
+    public ActionResult<IReadOnlyDictionary<int, string>> GetTaskLevelRatingRanges()
+    {
+        return Ok(ratingManager.GetTaskLevelRatingRanges());
+    }
+
     [HttpGet("{duelId:int}")]
     public async Task<ActionResult<DuelDto>> GetAsync(
         [FromRoute] int duelId,

--- a/Duely/tests/Duely.Domain.Tests/RatingManagerTests.cs
+++ b/Duely/tests/Duely.Domain.Tests/RatingManagerTests.cs
@@ -203,6 +203,27 @@ public class RatingManagerTests
     }
 
     [Fact]
+    public void GetTaskLevelRatingRanges_Returns_level_to_rating_mapping_from_options()
+    {
+        var ratingManager = new RatingManager(
+            Options.Create(new DuelOptions
+            {
+                DefaultMaxDurationMinutes = 30,
+                RatingToTaskLevelMapping =
+                [
+                    new RatingToTaskLevelMappingItem { Rating = "0-999", Level = 1 },
+                    new RatingToTaskLevelMappingItem { Rating = "1000-1999", Level = 2 }
+                ]
+            }));
+
+        ratingManager.GetTaskLevelRatingRanges().Should().BeEquivalentTo(new Dictionary<int, string>
+        {
+            [1] = "0-999",
+            [2] = "1000-1999"
+        });
+    }
+
+    [Fact]
     public void GetRatingChanges_Uses_correct_k_for_rating_boundaries()
     {
         var user1 = CreateUser(1, 1600);


### PR DESCRIPTION
## Что изменилось

- Добавлен `GET /duels/task-level-rating-ranges`, который возвращает словарь «уровень задачи → диапазон рейтинга» из конфигурации Duely.
- В `RatingManager` добавлено получение этого отображения.
- Добавлен тест преобразования конфигурации в диапазоны.

## Зачем

Фронтенду нужен единый источник диапазонов рейтинга, чтобы не дублировать конфигурацию Duely и показывать пользователям понятную сложность задач.

## Проверка

- `dotnet test --configuration Release` — 408 тестов пройдено.