### PR TITLE
feat(duely): add admin list endpoints

### DIFF
--- a/Duely/src/Duely.Application.UseCases/Dtos/GroupDto.cs
+++ b/Duely/src/Duely.Application.UseCases/Dtos/GroupDto.cs
@@ -12,5 +12,5 @@ public sealed class GroupDto
     public required string Name { get; init; }
 
     [JsonPropertyName("user_role"), JsonConverter(typeof(JsonStringEnumConverter))]
-    public required GroupRole UserRole { get; init; }
+    public GroupRole? UserRole { get; init; }
 }

--- a/Duely/src/Duely.Application.UseCases/Dtos/GroupListItemDto.cs
+++ b/Duely/src/Duely.Application.UseCases/Dtos/GroupListItemDto.cs
@@ -1,0 +1,12 @@
+using System.Text.Json.Serialization;
+
+namespace Duely.Application.UseCases.Dtos;
+
+public sealed class GroupListItemDto
+{
+    [JsonPropertyName("id")]
+    public required int Id { get; init; }
+
+    [JsonPropertyName("name")]
+    public required string Name { get; init; }
+}

--- a/Duely/src/Duely.Application.UseCases/Dtos/PendingDuelDto.cs
+++ b/Duely/src/Duely.Application.UseCases/Dtos/PendingDuelDto.cs
@@ -1,0 +1,40 @@
+using System.Text.Json.Serialization;
+using Duely.Domain.Models.Duels.Pending;
+
+namespace Duely.Application.UseCases.Dtos;
+
+public sealed class PendingDuelDto
+{
+    [JsonPropertyName("id")]
+    public required int Id { get; init; }
+
+    [JsonPropertyName("type"), JsonConverter(typeof(JsonStringEnumConverter))]
+    public required PendingDuelType Type { get; init; }
+
+    [JsonPropertyName("created_at")]
+    public required DateTime CreatedAt { get; init; }
+
+    [JsonPropertyName("user1")]
+    public required UserDto User1 { get; init; }
+
+    [JsonPropertyName("user2")]
+    public required UserDto User2 { get; init; }
+
+    [JsonPropertyName("is_accepted_by_user1")]
+    public required bool IsAcceptedByUser1 { get; init; }
+
+    [JsonPropertyName("is_accepted_by_user2")]
+    public required bool IsAcceptedByUser2 { get; init; }
+
+    [JsonPropertyName("group_id")]
+    public int? GroupId { get; init; }
+
+    [JsonPropertyName("group_name")]
+    public string? GroupName { get; init; }
+
+    [JsonPropertyName("tournament_id")]
+    public int? TournamentId { get; init; }
+
+    [JsonPropertyName("tournament_name")]
+    public string? TournamentName { get; init; }
+}

--- a/Duely/src/Duely.Application.UseCases/Dtos/RankedDuelSearcherDto.cs
+++ b/Duely/src/Duely.Application.UseCases/Dtos/RankedDuelSearcherDto.cs
@@ -1,0 +1,15 @@
+using System.Text.Json.Serialization;
+
+namespace Duely.Application.UseCases.Dtos;
+
+public sealed class RankedDuelSearcherDto
+{
+    [JsonPropertyName("user")]
+    public required UserDto User { get; init; }
+
+    [JsonPropertyName("rating")]
+    public required int Rating { get; init; }
+
+    [JsonPropertyName("search_started_at")]
+    public required DateTime SearchStartedAt { get; init; }
+}

--- a/Duely/src/Duely.Application.UseCases/Dtos/SubmissionListItemDto.cs
+++ b/Duely/src/Duely.Application.UseCases/Dtos/SubmissionListItemDto.cs
@@ -4,7 +4,7 @@ using Duely.Domain.Models.Duels;
 
 namespace Duely.Application.UseCases.Dtos;
 
-public sealed class SubmissionListItemDto
+public class SubmissionListItemDto
 {
     [JsonPropertyName("submission_id")]
     public required int SubmissionId { get; init; }
@@ -26,4 +26,13 @@ public sealed class SubmissionListItemDto
 
     [JsonPropertyName("is_upsolving")]
     public required bool IsUpsolving { get; set; }
+}
+
+public sealed class AdminSubmissionListItemDto : SubmissionListItemDto
+{
+    [JsonPropertyName("duel_id")]
+    public required int DuelId { get; init; }
+
+    [JsonPropertyName("task_key")]
+    public required char TaskKey { get; init; }
 }

--- a/Duely/src/Duely.Application.UseCases/Features/Duels/GetDuel.cs
+++ b/Duely/src/Duely.Application.UseCases/Features/Duels/GetDuel.cs
@@ -16,6 +16,7 @@ public sealed class GetDuelQuery : IRequest<Result<DuelDto>>
 {
     public required int UserId { get; init; }
     public required int DuelId { get; init; }
+    public bool IsAdmin { get; init; }
 }
 
 public sealed class GetDuelHandler(
@@ -41,6 +42,11 @@ public sealed class GetDuelHandler(
         if (duel is null)
         {
             return new EntityNotFoundError(nameof(Duel), nameof(Duel.Id), query.DuelId);
+        }
+
+        if (query.IsAdmin)
+        {
+            return DuelDtoMapper.Map(duel, ratingManager, taskService);
         }
 
         var isParticipant = duel.User1.Id == query.UserId || duel.User2.Id == query.UserId;

--- a/Duely/src/Duely.Application.UseCases/Features/Duels/GetGroupDuels.cs
+++ b/Duely/src/Duely.Application.UseCases/Features/Duels/GetGroupDuels.cs
@@ -16,6 +16,7 @@ public sealed class GetGroupDuelsQuery : IRequest<Result<List<GroupDuelDto>>>
 {
     public required int UserId { get; init; }
     public required int GroupId { get; init; }
+    public bool IsAdmin { get; init; }
 }
 
 public sealed class GetGroupDuelsHandler(
@@ -41,7 +42,7 @@ public sealed class GetGroupDuelsHandler(
             .AsNoTracking()
             .Where(m => m.Group.Id == group.Id && m.User.Id == query.UserId)
             .SingleOrDefaultAsync(cancellationToken);
-        if (membership is null || !groupPermissionsService.CanViewGroup(membership))
+        if (!query.IsAdmin && (membership is null || !groupPermissionsService.CanViewGroup(membership)))
         {
             return new ForbiddenError(nameof(Group), Operation, nameof(Group.Id), query.GroupId);
         }
@@ -81,7 +82,9 @@ public sealed class GetGroupDuelsHandler(
                 groupDuel.Duel.StartTime,
                 Dto = new GroupDuelDto
                 {
-                    Duel = DuelDtoMapper.Map(groupDuel.Duel, query.UserId, ratingManager, taskService),
+                    Duel = query.IsAdmin
+                        ? DuelDtoMapper.Map(groupDuel.Duel, ratingManager, taskService)
+                        : DuelDtoMapper.Map(groupDuel.Duel, query.UserId, ratingManager, taskService),
                     User1 = new UserDto
                     {
                         Id = groupDuel.Duel.User1.Id,

--- a/Duely/src/Duely.Application.UseCases/Features/Duels/ListAll.cs
+++ b/Duely/src/Duely.Application.UseCases/Features/Duels/ListAll.cs
@@ -1,0 +1,43 @@
+using Duely.Application.UseCases.Dtos;
+using Duely.Application.UseCases.Helpers;
+using Duely.Domain.Models.Duels;
+using Duely.Domain.Services.Duels;
+using Duely.Infrastructure.DataAccess.EntityFramework;
+using FluentResults;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Duely.Application.UseCases.Features.Duels;
+
+public sealed class GetDuelsByStatusQuery : IRequest<Result<List<DuelDto>>>
+{
+    public required DuelStatus Status { get; init; }
+}
+
+public sealed class GetDuelsByStatusHandler(
+    Context context,
+    IRatingManager ratingManager,
+    ITaskService taskService)
+    : IRequestHandler<GetDuelsByStatusQuery, Result<List<DuelDto>>>
+{
+    public async Task<Result<List<DuelDto>>> Handle(
+        GetDuelsByStatusQuery query,
+        CancellationToken cancellationToken)
+    {
+        var duels = await context.Duels
+            .AsNoTracking()
+            .Where(duel => duel.Status == query.Status)
+            .Include(duel => duel.Configuration)
+            .Include(duel => duel.User1)
+            .Include(duel => duel.User2)
+            .Include(duel => duel.Winner)
+            .Include(duel => duel.Submissions)
+            .ThenInclude(submission => submission.User)
+            .OrderByDescending(duel => duel.StartTime)
+            .ToListAsync(cancellationToken);
+
+        return duels
+            .Select(duel => DuelDtoMapper.Map(duel, ratingManager, taskService))
+            .ToList();
+    }
+}

--- a/Duely/src/Duely.Application.UseCases/Features/Duels/ListPending.cs
+++ b/Duely/src/Duely.Application.UseCases/Features/Duels/ListPending.cs
@@ -1,0 +1,141 @@
+using Duely.Application.UseCases.Dtos;
+using Duely.Domain.Models.Duels.Pending;
+using Duely.Infrastructure.DataAccess.EntityFramework;
+using FluentResults;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Duely.Application.UseCases.Features.Duels;
+
+public sealed class GetPendingDuelsQuery : IRequest<Result<List<PendingDuelDto>>>;
+
+public sealed class GetPendingDuelsHandler(Context context)
+    : IRequestHandler<GetPendingDuelsQuery, Result<List<PendingDuelDto>>>
+{
+    public async Task<Result<List<PendingDuelDto>>> Handle(
+        GetPendingDuelsQuery query,
+        CancellationToken cancellationToken)
+    {
+        var friendlyDuels = await context.PendingDuels
+            .AsNoTracking()
+            .OfType<FriendlyPendingDuel>()
+            .Select(duel => new PendingDuelDto
+            {
+                Id = duel.Id,
+                Type = duel.Type,
+                CreatedAt = duel.CreatedAt,
+                User1 = new UserDto
+                {
+                    Id = duel.User1.Id,
+                    Nickname = duel.User1.Nickname,
+                    Rating = duel.User1.Rating,
+                    CreatedAt = duel.User1.CreatedAt
+                },
+                User2 = new UserDto
+                {
+                    Id = duel.User2.Id,
+                    Nickname = duel.User2.Nickname,
+                    Rating = duel.User2.Rating,
+                    CreatedAt = duel.User2.CreatedAt
+                },
+                IsAcceptedByUser1 = true,
+                IsAcceptedByUser2 = duel.IsAccepted
+            })
+            .ToListAsync(cancellationToken);
+
+        var groupDuels = await context.PendingDuels
+            .AsNoTracking()
+            .OfType<GroupPendingDuel>()
+            .Select(duel => new PendingDuelDto
+            {
+                Id = duel.Id,
+                Type = duel.Type,
+                CreatedAt = duel.CreatedAt,
+                User1 = new UserDto
+                {
+                    Id = duel.User1.Id,
+                    Nickname = duel.User1.Nickname,
+                    Rating = duel.User1.Rating,
+                    CreatedAt = duel.User1.CreatedAt
+                },
+                User2 = new UserDto
+                {
+                    Id = duel.User2.Id,
+                    Nickname = duel.User2.Nickname,
+                    Rating = duel.User2.Rating,
+                    CreatedAt = duel.User2.CreatedAt
+                },
+                IsAcceptedByUser1 = duel.IsAcceptedByUser1,
+                IsAcceptedByUser2 = duel.IsAcceptedByUser2,
+                GroupId = duel.Group.Id,
+                GroupName = duel.Group.Name
+            })
+            .ToListAsync(cancellationToken);
+
+        var tournamentDuels = await context.PendingDuels
+            .AsNoTracking()
+            .OfType<TournamentPendingDuel>()
+            .Select(duel => new PendingDuelDto
+            {
+                Id = duel.Id,
+                Type = duel.Type,
+                CreatedAt = duel.CreatedAt,
+                User1 = new UserDto
+                {
+                    Id = duel.User1.Id,
+                    Nickname = duel.User1.Nickname,
+                    Rating = duel.User1.Rating,
+                    CreatedAt = duel.User1.CreatedAt
+                },
+                User2 = new UserDto
+                {
+                    Id = duel.User2.Id,
+                    Nickname = duel.User2.Nickname,
+                    Rating = duel.User2.Rating,
+                    CreatedAt = duel.User2.CreatedAt
+                },
+                IsAcceptedByUser1 = duel.IsAcceptedByUser1,
+                IsAcceptedByUser2 = duel.IsAcceptedByUser2,
+                GroupId = duel.Tournament.Group.Id,
+                GroupName = duel.Tournament.Group.Name,
+                TournamentId = duel.Tournament.Id,
+                TournamentName = duel.Tournament.Name
+            })
+            .ToListAsync(cancellationToken);
+
+        return friendlyDuels
+            .Concat(groupDuels)
+            .Concat(tournamentDuels)
+            .OrderByDescending(duel => duel.CreatedAt)
+            .ToList();
+    }
+}
+
+public sealed class GetRankedDuelSearchersQuery : IRequest<Result<List<RankedDuelSearcherDto>>>;
+
+public sealed class GetRankedDuelSearchersHandler(Context context)
+    : IRequestHandler<GetRankedDuelSearchersQuery, Result<List<RankedDuelSearcherDto>>>
+{
+    public async Task<Result<List<RankedDuelSearcherDto>>> Handle(
+        GetRankedDuelSearchersQuery query,
+        CancellationToken cancellationToken)
+    {
+        return await context.PendingDuels
+            .AsNoTracking()
+            .OfType<RankedPendingDuel>()
+            .OrderBy(duel => duel.CreatedAt)
+            .Select(duel => new RankedDuelSearcherDto
+            {
+                User = new UserDto
+                {
+                    Id = duel.User.Id,
+                    Nickname = duel.User.Nickname,
+                    Rating = duel.User.Rating,
+                    CreatedAt = duel.User.CreatedAt
+                },
+                Rating = duel.Rating,
+                SearchStartedAt = duel.CreatedAt
+            })
+            .ToListAsync(cancellationToken);
+    }
+}

--- a/Duely/src/Duely.Application.UseCases/Features/Groups/Get.cs
+++ b/Duely/src/Duely.Application.UseCases/Features/Groups/Get.cs
@@ -13,6 +13,7 @@ public sealed class GetGroupQuery : IRequest<Result<GroupDto>>
 {
     public required int UserId { get; init; }
     public required int GroupId { get; init; }
+    public bool IsAdmin { get; init; }
 }
 
 public sealed class GetGroupHandler(Context context, IGroupPermissionsService groupPermissionsService)
@@ -34,7 +35,7 @@ public sealed class GetGroupHandler(Context context, IGroupPermissionsService gr
             .AsNoTracking()
             .Where(m => m.Group.Id == group.Id && m.User.Id == query.UserId)
             .SingleOrDefaultAsync(cancellationToken);
-        if (membership is null || !groupPermissionsService.CanViewGroup(membership))
+        if (!query.IsAdmin && (membership is null || !groupPermissionsService.CanViewGroup(membership)))
         {
             return new ForbiddenError(nameof(Group), Operation, nameof(Group.Id), query.GroupId);
         }
@@ -43,7 +44,7 @@ public sealed class GetGroupHandler(Context context, IGroupPermissionsService gr
         {
             Id = group.Id,
             Name = group.Name,
-            UserRole = membership.Role
+            UserRole = membership?.Role
         };
     }
 }

--- a/Duely/src/Duely.Application.UseCases/Features/Groups/GetUsers.cs
+++ b/Duely/src/Duely.Application.UseCases/Features/Groups/GetUsers.cs
@@ -13,6 +13,7 @@ public sealed class GetGroupUsersQuery : IRequest<Result<List<GroupUserDto>>>
 {
     public required int UserId { get; init; }
     public required int GroupId { get; init; }
+    public bool IsAdmin { get; init; }
 }
 
 public sealed class GetGroupUsersHandler(Context context, IGroupPermissionsService groupPermissionsService)
@@ -34,7 +35,7 @@ public sealed class GetGroupUsersHandler(Context context, IGroupPermissionsServi
             .AsNoTracking()
             .Where(m => m.Group.Id == group.Id && m.User.Id == query.UserId)
             .SingleOrDefaultAsync(cancellationToken);
-        if (membership is null || !groupPermissionsService.CanViewGroup(membership))
+        if (!query.IsAdmin && (membership is null || !groupPermissionsService.CanViewGroup(membership)))
         {
             return new ForbiddenError(nameof(Group), Operation, nameof(Group.Id), query.GroupId);
         }

--- a/Duely/src/Duely.Application.UseCases/Features/Groups/ListAll.cs
+++ b/Duely/src/Duely.Application.UseCases/Features/Groups/ListAll.cs
@@ -1,0 +1,28 @@
+using Duely.Application.UseCases.Dtos;
+using Duely.Infrastructure.DataAccess.EntityFramework;
+using FluentResults;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Duely.Application.UseCases.Features.Groups;
+
+public sealed class GetAllGroupsQuery : IRequest<Result<List<GroupListItemDto>>>;
+
+public sealed class GetAllGroupsHandler(Context context)
+    : IRequestHandler<GetAllGroupsQuery, Result<List<GroupListItemDto>>>
+{
+    public async Task<Result<List<GroupListItemDto>>> Handle(
+        GetAllGroupsQuery query,
+        CancellationToken cancellationToken)
+    {
+        return await context.Groups
+            .AsNoTracking()
+            .OrderBy(group => group.Name)
+            .Select(group => new GroupListItemDto
+            {
+                Id = group.Id,
+                Name = group.Name
+            })
+            .ToListAsync(cancellationToken);
+    }
+}

--- a/Duely/src/Duely.Application.UseCases/Features/Submissions/Get.cs
+++ b/Duely/src/Duely.Application.UseCases/Features/Submissions/Get.cs
@@ -13,6 +13,7 @@ public sealed class GetSubmissionQuery : IRequest<Result<SubmissionDto>>
     public required int SubmissionId { get; init; }
     public required int UserId { get; init; }
     public required int DuelId { get; init; }
+    public bool IsAdmin { get; init; }
 }
 
 public sealed class GetSubmissionHandler(Context context)
@@ -30,15 +31,15 @@ public sealed class GetSubmissionHandler(Context context)
             return new EntityNotFoundError(nameof(Submission), nameof(Submission.Id), query.SubmissionId);
         }
 
-        var isOwner = submission.User.Id == query.UserId;
+        var canViewDetails = submission.User.Id == query.UserId || query.IsAdmin;
         return new SubmissionDto
         {
             SubmissionId = submission.Id,
-            Solution = isOwner ? submission.Solution : string.Empty,
+            Solution = canViewDetails ? submission.Solution : string.Empty,
             Language = submission.Language,
             Status = submission.Status,
             CreatedAt = submission.SubmitTime,
-            Message = isOwner ? submission.Message : null,
+            Message = canViewDetails ? submission.Message : null,
             Verdict = submission.Verdict,
             IsUpsolving = submission.IsUpsolving
         };

--- a/Duely/src/Duely.Application.UseCases/Features/Submissions/List.cs
+++ b/Duely/src/Duely.Application.UseCases/Features/Submissions/List.cs
@@ -15,6 +15,7 @@ public sealed class GetUserSubmissionsQuery : IRequest<Result<List<SubmissionLis
     public required int UserId { get; init; }
     public required int DuelId { get; init; }
     public required char TaskKey { get; init; }
+    public bool IsAdmin { get; init; }
 }
 
 public sealed class GetUserSubmissionsHandler(
@@ -36,7 +37,7 @@ public sealed class GetUserSubmissionsHandler(
         }
 
         var isParticipant = duel.User1.Id == query.UserId || duel.User2.Id == query.UserId;
-        if (!isParticipant)
+        if (!isParticipant && !query.IsAdmin)
         {
             var canViewDuel = await CanViewGroupDuel(query.UserId, query.DuelId, cancellationToken);
             if (!canViewDuel)
@@ -46,7 +47,7 @@ public sealed class GetUserSubmissionsHandler(
         }
 
         var submissionsQuery = context.Submissions.Where(s => s.Duel.Id == duel.Id && s.TaskKey == query.TaskKey);
-        if (isParticipant)
+        if (isParticipant && !query.IsAdmin)
         {
             submissionsQuery = submissionsQuery.Where(s => s.User.Id == query.UserId);
         }

--- a/Duely/src/Duely.Application.UseCases/Features/Submissions/ListAll.cs
+++ b/Duely/src/Duely.Application.UseCases/Features/Submissions/ListAll.cs
@@ -1,0 +1,48 @@
+using Duely.Application.UseCases.Dtos;
+using Duely.Domain.Models;
+using Duely.Infrastructure.DataAccess.EntityFramework;
+using FluentResults;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Duely.Application.UseCases.Features.Submissions;
+
+public sealed class GetAllSubmissionsQuery : IRequest<Result<List<SubmissionListItemDto>>>
+{
+    public bool OnlyTesting { get; init; }
+}
+
+public sealed class GetAllSubmissionsHandler(Context context)
+    : IRequestHandler<GetAllSubmissionsQuery, Result<List<SubmissionListItemDto>>>
+{
+    public async Task<Result<List<SubmissionListItemDto>>> Handle(
+        GetAllSubmissionsQuery query,
+        CancellationToken cancellationToken)
+    {
+        var submissions = context.Submissions.AsNoTracking();
+        if (query.OnlyTesting)
+        {
+            submissions = submissions.Where(submission => submission.Status != SubmissionStatus.Done);
+        }
+
+        return await submissions
+            .OrderByDescending(submission => submission.SubmitTime)
+            .Select(submission => new SubmissionListItemDto
+            {
+                SubmissionId = submission.Id,
+                Status = submission.Status,
+                Language = submission.Language,
+                Author = new UserDto
+                {
+                    Id = submission.User.Id,
+                    Nickname = submission.User.Nickname,
+                    Rating = submission.User.Rating,
+                    CreatedAt = submission.User.CreatedAt
+                },
+                CreatedAt = submission.SubmitTime,
+                Verdict = submission.Verdict,
+                IsUpsolving = submission.IsUpsolving
+            })
+            .ToListAsync(cancellationToken);
+    }
+}

--- a/Duely/src/Duely.Application.UseCases/Features/Submissions/ListAll.cs
+++ b/Duely/src/Duely.Application.UseCases/Features/Submissions/ListAll.cs
@@ -7,15 +7,15 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Duely.Application.UseCases.Features.Submissions;
 
-public sealed class GetAllSubmissionsQuery : IRequest<Result<List<SubmissionListItemDto>>>
+public sealed class GetAllSubmissionsQuery : IRequest<Result<List<AdminSubmissionListItemDto>>>
 {
     public bool OnlyTesting { get; init; }
 }
 
 public sealed class GetAllSubmissionsHandler(Context context)
-    : IRequestHandler<GetAllSubmissionsQuery, Result<List<SubmissionListItemDto>>>
+    : IRequestHandler<GetAllSubmissionsQuery, Result<List<AdminSubmissionListItemDto>>>
 {
-    public async Task<Result<List<SubmissionListItemDto>>> Handle(
+    public async Task<Result<List<AdminSubmissionListItemDto>>> Handle(
         GetAllSubmissionsQuery query,
         CancellationToken cancellationToken)
     {
@@ -27,9 +27,11 @@ public sealed class GetAllSubmissionsHandler(Context context)
 
         return await submissions
             .OrderByDescending(submission => submission.SubmitTime)
-            .Select(submission => new SubmissionListItemDto
+            .Select(submission => new AdminSubmissionListItemDto
             {
                 SubmissionId = submission.Id,
+                DuelId = submission.Duel.Id,
+                TaskKey = submission.TaskKey,
                 Status = submission.Status,
                 Language = submission.Language,
                 Author = new UserDto

--- a/Duely/src/Duely.Application.UseCases/Features/Tournaments/GetGroupTournaments.cs
+++ b/Duely/src/Duely.Application.UseCases/Features/Tournaments/GetGroupTournaments.cs
@@ -14,6 +14,7 @@ public sealed class GetGroupTournamentsQuery : IRequest<Result<List<TournamentDt
 {
     public required int UserId { get; init; }
     public required int GroupId { get; init; }
+    public bool IsAdmin { get; init; }
 }
 
 public sealed class GetGroupTournamentsHandler(Context context, IGroupPermissionsService groupPermissionsService)
@@ -38,7 +39,7 @@ public sealed class GetGroupTournamentsHandler(Context context, IGroupPermission
             .SingleOrDefaultAsync(
                 m => m.Group.Id == query.GroupId && m.User.Id == query.UserId,
                 cancellationToken);
-        if (membership is null || !groupPermissionsService.CanViewGroup(membership))
+        if (!query.IsAdmin && (membership is null || !groupPermissionsService.CanViewGroup(membership)))
         {
             return new ForbiddenError(nameof(Group), Operation, nameof(Group.Id), query.GroupId);
         }

--- a/Duely/src/Duely.Application.UseCases/Features/Tournaments/GetTournament.cs
+++ b/Duely/src/Duely.Application.UseCases/Features/Tournaments/GetTournament.cs
@@ -15,6 +15,7 @@ public sealed class GetTournamentQuery : IRequest<Result<TournamentDetailsDto>>
 {
     public required int UserId { get; init; }
     public required int TournamentId { get; init; }
+    public bool IsAdmin { get; init; }
 }
 
 public sealed class GetTournamentHandler(
@@ -43,7 +44,7 @@ public sealed class GetTournamentHandler(
         }
 
         var membership = tournament.Group.Users.SingleOrDefault(m => m.User.Id == query.UserId);
-        if (membership is null || !groupPermissionsService.CanViewGroup(membership))
+        if (!query.IsAdmin && (membership is null || !groupPermissionsService.CanViewGroup(membership)))
         {
             return new ForbiddenError(nameof(Group), Operation, nameof(Group.Id), tournament.Group.Id);
         }

--- a/Duely/src/Duely.Application.UseCases/Features/Tournaments/ListAll.cs
+++ b/Duely/src/Duely.Application.UseCases/Features/Tournaments/ListAll.cs
@@ -1,0 +1,39 @@
+using Duely.Application.UseCases.Dtos;
+using Duely.Application.UseCases.Helpers;
+using Duely.Domain.Models.Tournaments;
+using Duely.Infrastructure.DataAccess.EntityFramework;
+using FluentResults;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Duely.Application.UseCases.Features.Tournaments;
+
+public sealed class GetTournamentsByStateQuery : IRequest<Result<List<TournamentDto>>>
+{
+    public required bool Finished { get; init; }
+}
+
+public sealed class GetTournamentsByStateHandler(Context context)
+    : IRequestHandler<GetTournamentsByStateQuery, Result<List<TournamentDto>>>
+{
+    public async Task<Result<List<TournamentDto>>> Handle(
+        GetTournamentsByStateQuery query,
+        CancellationToken cancellationToken)
+    {
+        var tournaments = context.Tournaments.AsNoTracking();
+        tournaments = query.Finished
+            ? tournaments.Where(tournament => tournament.Status == TournamentStatus.Finished)
+            : tournaments.Where(tournament => tournament.Status != TournamentStatus.Finished);
+
+        var result = await tournaments
+            .Include(tournament => tournament.Group)
+            .Include(tournament => tournament.CreatedBy)
+            .Include(tournament => tournament.DuelConfiguration)
+            .Include(tournament => tournament.Participants)
+            .ThenInclude(participant => participant.User)
+            .OrderByDescending(tournament => tournament.CreatedAt)
+            .ToListAsync(cancellationToken);
+
+        return result.Select(TournamentDtoMapper.Map).ToList();
+    }
+}

--- a/Duely/src/Duely.Application.UseCases/Features/Users/List.cs
+++ b/Duely/src/Duely.Application.UseCases/Features/Users/List.cs
@@ -1,0 +1,43 @@
+using Duely.Application.UseCases.Dtos;
+using Duely.Infrastructure.DataAccess.EntityFramework;
+using FluentResults;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Duely.Application.UseCases.Features.Users;
+
+public sealed class GetUsersQuery : IRequest<Result<List<UserDto>>>
+{
+    public IReadOnlyCollection<int>? UserIds { get; init; }
+}
+
+public sealed class GetUsersHandler(Context context)
+    : IRequestHandler<GetUsersQuery, Result<List<UserDto>>>
+{
+    public async Task<Result<List<UserDto>>> Handle(
+        GetUsersQuery query,
+        CancellationToken cancellationToken)
+    {
+        if (query.UserIds is { Count: 0 })
+        {
+            return new List<UserDto>();
+        }
+
+        var users = context.Users.AsNoTracking();
+        if (query.UserIds is not null)
+        {
+            users = users.Where(user => query.UserIds.Contains(user.Id));
+        }
+
+        return await users
+            .OrderByDescending(user => user.CreatedAt)
+            .Select(user => new UserDto
+            {
+                Id = user.Id,
+                Nickname = user.Nickname,
+                Rating = user.Rating,
+                CreatedAt = user.CreatedAt
+            })
+            .ToListAsync(cancellationToken);
+    }
+}

--- a/Duely/src/Duely.Application.UseCases/Helpers/DuelDtoMapper.cs
+++ b/Duely/src/Duely.Application.UseCases/Helpers/DuelDtoMapper.cs
@@ -8,7 +8,24 @@ public static class DuelDtoMapper
 {
     public static DuelDto Map(
         Duel duel,
+        IRatingManager ratingManager,
+        ITaskService taskService)
+    {
+        return Map(duel, null, ratingManager, taskService);
+    }
+
+    public static DuelDto Map(
+        Duel duel,
         int viewerId,
+        IRatingManager ratingManager,
+        ITaskService taskService)
+    {
+        return Map(duel, (int?)viewerId, ratingManager, taskService);
+    }
+
+    private static DuelDto Map(
+        Duel duel,
+        int? viewerId,
         IRatingManager ratingManager,
         ITaskService taskService)
     {
@@ -19,9 +36,10 @@ public static class DuelDtoMapper
             [duel.User2.Id] = ratingManager.GetRatingChanges(duel, duel.User2InitRating, duel.User1InitRating)
         };
 
-        var isParticipant = duel.User1.Id == viewerId || duel.User2.Id == viewerId;
+        var isParticipant = viewerId.HasValue &&
+                            (duel.User1.Id == viewerId.Value || duel.User2.Id == viewerId.Value);
         var visibleTasks = isParticipant
-            ? taskService.GetVisibleTasks(duel, viewerId)
+            ? taskService.GetVisibleTasks(duel, viewerId!.Value)
             : duel.Tasks;
 
         var tasks = MapTasks(duel.Tasks, visibleTasks);
@@ -30,12 +48,12 @@ public static class DuelDtoMapper
         if (isParticipant)
         {
             solutions = MapSolutions(
-                duel.User1.Id == viewerId ? duel.User1Solutions : duel.User2Solutions,
+                duel.User1.Id == viewerId!.Value ? duel.User1Solutions : duel.User2Solutions,
                 visibleTasks.Keys);
             if (duel.Configuration.ShouldShowOpponentSolution)
             {
                 opponentSolutions = MapSolutions(
-                    duel.User1.Id == viewerId ? duel.User2Solutions : duel.User1Solutions,
+                    duel.User1.Id == viewerId.Value ? duel.User2Solutions : duel.User1Solutions,
                     visibleTasks.Keys);
             }
         }

--- a/Duely/src/Duely.Infrastructure.Api.Http/Controllers/DuelsController.cs
+++ b/Duely/src/Duely.Infrastructure.Api.Http/Controllers/DuelsController.cs
@@ -70,7 +70,8 @@ public sealed class DuelsController(
         var query = new GetDuelQuery
         {
             UserId = userContext.UserId,
-            DuelId = duelId
+            DuelId = duelId,
+            IsAdmin = userContext.IsAdmin()
         };
 
         var result = await mediator.Send(query, cancellationToken);

--- a/Duely/src/Duely.Infrastructure.Api.Http/Controllers/DuelsController.cs
+++ b/Duely/src/Duely.Infrastructure.Api.Http/Controllers/DuelsController.cs
@@ -2,6 +2,7 @@ using Duely.Application.UseCases.Dtos;
 using Duely.Application.UseCases.Features.Duels;
 using Duely.Application.UseCases.Features.Duels.Search;
 using Duely.Domain.Services.Duels;
+using Duely.Domain.Models.Duels;
 using Duely.Infrastructure.Api.Http.Services;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
@@ -17,6 +18,44 @@ public sealed class DuelsController(
     IUserContext userContext,
     IRatingManager ratingManager) : ControllerBase
 {
+    [HttpGet("admin/pending")]
+    [Authorize(Policy = AuthorizationPolicies.OnlyAdmin)]
+    public async Task<ActionResult<List<PendingDuelDto>>> GetPendingForAdminAsync(
+        CancellationToken cancellationToken)
+    {
+        var result = await mediator.Send(new GetPendingDuelsQuery(), cancellationToken);
+        return this.HandleResult(result);
+    }
+
+    [HttpGet("admin/ranked-searchers")]
+    [Authorize(Policy = AuthorizationPolicies.OnlyAdmin)]
+    public async Task<ActionResult<List<RankedDuelSearcherDto>>> GetRankedSearchersForAdminAsync(
+        CancellationToken cancellationToken)
+    {
+        var result = await mediator.Send(new GetRankedDuelSearchersQuery(), cancellationToken);
+        return this.HandleResult(result);
+    }
+
+    [HttpGet("admin/active")]
+    [Authorize(Policy = AuthorizationPolicies.OnlyAdmin)]
+    public async Task<ActionResult<List<DuelDto>>> GetAllActiveForAdminAsync(
+        CancellationToken cancellationToken)
+    {
+        var query = new GetDuelsByStatusQuery { Status = DuelStatus.InProgress };
+        var result = await mediator.Send(query, cancellationToken);
+        return this.HandleResult(result);
+    }
+
+    [HttpGet("admin/finished")]
+    [Authorize(Policy = AuthorizationPolicies.OnlyAdmin)]
+    public async Task<ActionResult<List<DuelDto>>> GetAllFinishedForAdminAsync(
+        CancellationToken cancellationToken)
+    {
+        var query = new GetDuelsByStatusQuery { Status = DuelStatus.Finished };
+        var result = await mediator.Send(query, cancellationToken);
+        return this.HandleResult(result);
+    }
+
     [HttpGet("task-level-rating-ranges")]
     public ActionResult<IReadOnlyDictionary<int, string>> GetTaskLevelRatingRanges()
     {

--- a/Duely/src/Duely.Infrastructure.Api.Http/Controllers/GroupsController.cs
+++ b/Duely/src/Duely.Infrastructure.Api.Http/Controllers/GroupsController.cs
@@ -47,7 +47,8 @@ public sealed class GroupsController(IMediator mediator, IUserContext userContex
         var query = new GetGroupQuery
         {
             UserId = userContext.UserId,
-            GroupId = id
+            GroupId = id,
+            IsAdmin = userContext.IsAdmin()
         };
 
         var result = await mediator.Send(query, cancellationToken);
@@ -91,7 +92,8 @@ public sealed class GroupsController(IMediator mediator, IUserContext userContex
         var query = new GetGroupUsersQuery
         {
             UserId = userContext.UserId,
-            GroupId = id
+            GroupId = id,
+            IsAdmin = userContext.IsAdmin()
         };
 
         var result = await mediator.Send(query, cancellationToken);
@@ -156,7 +158,8 @@ public sealed class GroupsController(IMediator mediator, IUserContext userContex
         var query = new GetGroupDuelsQuery
         {
             UserId = userContext.UserId,
-            GroupId = id
+            GroupId = id,
+            IsAdmin = userContext.IsAdmin()
         };
 
         var result = await mediator.Send(query, cancellationToken);
@@ -171,7 +174,8 @@ public sealed class GroupsController(IMediator mediator, IUserContext userContex
         var query = new GetGroupTournamentsQuery
         {
             UserId = userContext.UserId,
-            GroupId = id
+            GroupId = id,
+            IsAdmin = userContext.IsAdmin()
         };
 
         var result = await mediator.Send(query, cancellationToken);

--- a/Duely/src/Duely.Infrastructure.Api.Http/Controllers/GroupsController.cs
+++ b/Duely/src/Duely.Infrastructure.Api.Http/Controllers/GroupsController.cs
@@ -15,6 +15,15 @@ namespace Duely.Infrastructure.Api.Http.Controllers;
 [Authorize]
 public sealed class GroupsController(IMediator mediator, IUserContext userContext) : ControllerBase
 {
+    [HttpGet("admin/all")]
+    [Authorize(Policy = AuthorizationPolicies.OnlyAdmin)]
+    public async Task<ActionResult<List<GroupListItemDto>>> GetAllForAdminAsync(
+        CancellationToken cancellationToken)
+    {
+        var result = await mediator.Send(new GetAllGroupsQuery(), cancellationToken);
+        return this.HandleResult(result);
+    }
+
     [HttpPost]
     public async Task<ActionResult<GroupDto>> CreateAsync(
         [FromBody] CreateGroupRequest request,

--- a/Duely/src/Duely.Infrastructure.Api.Http/Controllers/SubmissionsController.cs
+++ b/Duely/src/Duely.Infrastructure.Api.Http/Controllers/SubmissionsController.cs
@@ -15,7 +15,7 @@ public sealed class SubmissionsController(IMediator mediator, IUserContext userC
 {
     [HttpGet("~/duels/admin/submissions/testing")]
     [Authorize(Policy = AuthorizationPolicies.OnlyAdmin)]
-    public async Task<ActionResult<List<SubmissionListItemDto>>> GetTestingForAdminAsync(
+    public async Task<ActionResult<List<AdminSubmissionListItemDto>>> GetTestingForAdminAsync(
         CancellationToken cancellationToken)
     {
         var query = new GetAllSubmissionsQuery { OnlyTesting = true };
@@ -25,7 +25,7 @@ public sealed class SubmissionsController(IMediator mediator, IUserContext userC
 
     [HttpGet("~/duels/admin/submissions/all")]
     [Authorize(Policy = AuthorizationPolicies.OnlyAdmin)]
-    public async Task<ActionResult<List<SubmissionListItemDto>>> GetAllForAdminAsync(
+    public async Task<ActionResult<List<AdminSubmissionListItemDto>>> GetAllForAdminAsync(
         CancellationToken cancellationToken)
     {
         var result = await mediator.Send(new GetAllSubmissionsQuery(), cancellationToken);
@@ -61,7 +61,8 @@ public sealed class SubmissionsController(IMediator mediator, IUserContext userC
         {
             DuelId = duelId,
             UserId = userContext.UserId,
-            TaskKey = taskKey
+            TaskKey = taskKey,
+            IsAdmin = userContext.IsAdmin()
         };
 
         var result = await mediator.Send(query, cancellationToken);

--- a/Duely/src/Duely.Infrastructure.Api.Http/Controllers/SubmissionsController.cs
+++ b/Duely/src/Duely.Infrastructure.Api.Http/Controllers/SubmissionsController.cs
@@ -13,6 +13,25 @@ namespace Duely.Infrastructure.Api.Http.Controllers;
 [Authorize]
 public sealed class SubmissionsController(IMediator mediator, IUserContext userContext) : ControllerBase
 {
+    [HttpGet("~/duels/admin/submissions/testing")]
+    [Authorize(Policy = AuthorizationPolicies.OnlyAdmin)]
+    public async Task<ActionResult<List<SubmissionListItemDto>>> GetTestingForAdminAsync(
+        CancellationToken cancellationToken)
+    {
+        var query = new GetAllSubmissionsQuery { OnlyTesting = true };
+        var result = await mediator.Send(query, cancellationToken);
+        return this.HandleResult(result);
+    }
+
+    [HttpGet("~/duels/admin/submissions/all")]
+    [Authorize(Policy = AuthorizationPolicies.OnlyAdmin)]
+    public async Task<ActionResult<List<SubmissionListItemDto>>> GetAllForAdminAsync(
+        CancellationToken cancellationToken)
+    {
+        var result = await mediator.Send(new GetAllSubmissionsQuery(), cancellationToken);
+        return this.HandleResult(result);
+    }
+
     [HttpPost]
     public async Task<ActionResult<SubmissionDto>> SendSubmissionAsync(
         [FromRoute] int duelId,

--- a/Duely/src/Duely.Infrastructure.Api.Http/Controllers/SubmissionsController.cs
+++ b/Duely/src/Duely.Infrastructure.Api.Http/Controllers/SubmissionsController.cs
@@ -78,7 +78,8 @@ public sealed class SubmissionsController(IMediator mediator, IUserContext userC
         {
             UserId = userContext.UserId,
             DuelId = duelId,
-            SubmissionId = submissionId
+            SubmissionId = submissionId,
+            IsAdmin = userContext.IsAdmin()
         };
 
         var result = await mediator.Send(query, cancellationToken);

--- a/Duely/src/Duely.Infrastructure.Api.Http/Controllers/TournamentsController.cs
+++ b/Duely/src/Duely.Infrastructure.Api.Http/Controllers/TournamentsController.cs
@@ -13,6 +13,26 @@ namespace Duely.Infrastructure.Api.Http.Controllers;
 [Authorize]
 public sealed class TournamentsController(IMediator mediator, IUserContext userContext) : ControllerBase
 {
+    [HttpGet("admin/active")]
+    [Authorize(Policy = AuthorizationPolicies.OnlyAdmin)]
+    public async Task<ActionResult<List<TournamentDto>>> GetActiveForAdminAsync(
+        CancellationToken cancellationToken)
+    {
+        var query = new GetTournamentsByStateQuery { Finished = false };
+        var result = await mediator.Send(query, cancellationToken);
+        return this.HandleResult(result);
+    }
+
+    [HttpGet("admin/finished")]
+    [Authorize(Policy = AuthorizationPolicies.OnlyAdmin)]
+    public async Task<ActionResult<List<TournamentDto>>> GetFinishedForAdminAsync(
+        CancellationToken cancellationToken)
+    {
+        var query = new GetTournamentsByStateQuery { Finished = true };
+        var result = await mediator.Send(query, cancellationToken);
+        return this.HandleResult(result);
+    }
+
     [HttpGet("{id:int}")]
     public async Task<ActionResult<TournamentDetailsDto>> GetAsync(
         [FromRoute] int id,

--- a/Duely/src/Duely.Infrastructure.Api.Http/Controllers/TournamentsController.cs
+++ b/Duely/src/Duely.Infrastructure.Api.Http/Controllers/TournamentsController.cs
@@ -41,7 +41,8 @@ public sealed class TournamentsController(IMediator mediator, IUserContext userC
         var query = new GetTournamentQuery
         {
             UserId = userContext.UserId,
-            TournamentId = id
+            TournamentId = id,
+            IsAdmin = userContext.IsAdmin()
         };
 
         var result = await mediator.Send(query, cancellationToken);

--- a/Duely/src/Duely.Infrastructure.Api.Http/Controllers/UsersController.cs
+++ b/Duely/src/Duely.Infrastructure.Api.Http/Controllers/UsersController.cs
@@ -32,7 +32,7 @@ public sealed class UsersController(
     {
         var query = new GetUsersQuery
         {
-            UserIds = webSocketConnectionManager.GetConnectedUserIds()
+            UserIds = webSocketConnectionManager.GetLocallyConnectedUserIds()
         };
 
         var result = await mediator.Send(query, cancellationToken);

--- a/Duely/src/Duely.Infrastructure.Api.Http/Controllers/UsersController.cs
+++ b/Duely/src/Duely.Infrastructure.Api.Http/Controllers/UsersController.cs
@@ -15,8 +15,30 @@ namespace Duely.Infrastructure.Api.Http.Controllers;
 public sealed class UsersController(
     IMediator mediator,
     IUserContext userContext,
-    IUserWebSocketHandler webSocketHandler) : ControllerBase
+    IUserWebSocketHandler webSocketHandler,
+    IWebSocketConnectionManager webSocketConnectionManager) : ControllerBase
 {
+    [HttpGet("admin/all")]
+    [Authorize(Policy = AuthorizationPolicies.OnlyAdmin)]
+    public async Task<ActionResult<List<UserDto>>> GetAllForAdminAsync(CancellationToken cancellationToken)
+    {
+        var result = await mediator.Send(new GetUsersQuery(), cancellationToken);
+        return this.HandleResult(result);
+    }
+
+    [HttpGet("admin/active")]
+    [Authorize(Policy = AuthorizationPolicies.OnlyAdmin)]
+    public async Task<ActionResult<List<UserDto>>> GetActiveForAdminAsync(CancellationToken cancellationToken)
+    {
+        var query = new GetUsersQuery
+        {
+            UserIds = webSocketConnectionManager.GetConnectedUserIds()
+        };
+
+        var result = await mediator.Send(query, cancellationToken);
+        return this.HandleResult(result);
+    }
+
     [HttpPost("register")]
     public async Task<IActionResult> RegisterAsync(
         [FromBody] RegisterRequest request,

--- a/Duely/src/Duely.Infrastructure.Api.Http/Services/WebSockets/WebSocketConnectionManager.cs
+++ b/Duely/src/Duely.Infrastructure.Api.Http/Services/WebSockets/WebSocketConnectionManager.cs
@@ -8,6 +8,7 @@ public interface IWebSocketConnectionManager
     void RemoveConnection(Guid connectionId);
     List<WebSocket> GetSockets(int userId);
     bool HasSockets(int userId);
+    IReadOnlyCollection<int> GetConnectedUserIds();
 }
 
 public sealed class WebSocketConnectionManager : IWebSocketConnectionManager
@@ -79,6 +80,14 @@ public sealed class WebSocketConnectionManager : IWebSocketConnectionManager
         lock (_lock)
         {
             return _connections.ContainsKey(userId);
+        }
+    }
+
+    public IReadOnlyCollection<int> GetConnectedUserIds()
+    {
+        lock (_lock)
+        {
+            return _connections.Keys.ToArray();
         }
     }
 }

--- a/Duely/src/Duely.Infrastructure.Api.Http/Services/WebSockets/WebSocketConnectionManager.cs
+++ b/Duely/src/Duely.Infrastructure.Api.Http/Services/WebSockets/WebSocketConnectionManager.cs
@@ -8,7 +8,7 @@ public interface IWebSocketConnectionManager
     void RemoveConnection(Guid connectionId);
     List<WebSocket> GetSockets(int userId);
     bool HasSockets(int userId);
-    IReadOnlyCollection<int> GetConnectedUserIds();
+    IReadOnlyCollection<int> GetLocallyConnectedUserIds();
 }
 
 public sealed class WebSocketConnectionManager : IWebSocketConnectionManager
@@ -83,7 +83,7 @@ public sealed class WebSocketConnectionManager : IWebSocketConnectionManager
         }
     }
 
-    public IReadOnlyCollection<int> GetConnectedUserIds()
+    public IReadOnlyCollection<int> GetLocallyConnectedUserIds()
     {
         lock (_lock)
         {

--- a/Duely/tests/Duely.Application.Tests/Handlers/AdminListHandlersTests.cs
+++ b/Duely/tests/Duely.Application.Tests/Handlers/AdminListHandlersTests.cs
@@ -193,6 +193,8 @@ public sealed class AdminListHandlersTests : ContextBasedTest
 
         testingResult.Value.Select(submission => submission.SubmissionId).Should().Equal(running.Id, queued.Id);
         allResult.Value.Select(submission => submission.SubmissionId).Should().Equal(done.Id, running.Id, queued.Id);
+        allResult.Value.Should().OnlyContain(submission => submission.DuelId == duel.Id);
+        allResult.Value.Should().OnlyContain(submission => submission.TaskKey == 'A');
     }
 
     [Fact]

--- a/Duely/tests/Duely.Application.Tests/Handlers/AdminListHandlersTests.cs
+++ b/Duely/tests/Duely.Application.Tests/Handlers/AdminListHandlersTests.cs
@@ -1,0 +1,281 @@
+using Duely.Application.Tests.TestHelpers;
+using Duely.Application.UseCases.Features.Duels;
+using Duely.Application.UseCases.Features.Groups;
+using Duely.Application.UseCases.Features.Submissions;
+using Duely.Application.UseCases.Features.Tournaments;
+using Duely.Application.UseCases.Features.Users;
+using Duely.Domain.Models;
+using Duely.Domain.Models.Duels;
+using Duely.Domain.Models.Duels.Pending;
+using Duely.Domain.Models.Groups;
+using Duely.Domain.Models.Tournaments;
+using Duely.Domain.Services.Duels;
+using FluentAssertions;
+using Moq;
+
+namespace Duely.Application.Tests.Handlers;
+
+public sealed class AdminListHandlersTests : ContextBasedTest
+{
+    [Fact]
+    public async Task GetUsers_filters_connected_ids_and_orders_by_creation_time()
+    {
+        var older = MakeUser(1, "older", DateTime.UtcNow.AddDays(-2));
+        var newer = MakeUser(2, "newer", DateTime.UtcNow.AddDays(-1));
+        var disconnected = MakeUser(3, "disconnected", DateTime.UtcNow);
+        Context.Users.AddRange(older, newer, disconnected);
+        await Context.SaveChangesAsync();
+
+        var handler = new GetUsersHandler(Context);
+        var result = await handler.Handle(
+            new GetUsersQuery { UserIds = [older.Id, newer.Id] },
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Select(user => user.Id).Should().Equal(newer.Id, older.Id);
+
+        var emptyResult = await handler.Handle(
+            new GetUsersQuery { UserIds = [] },
+            CancellationToken.None);
+        emptyResult.Value.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetPendingDuels_returns_non_ranked_types_and_ranked_searchers_separately()
+    {
+        var user1 = MakeUser(1, "u1", DateTime.UtcNow.AddDays(-2));
+        var user2 = MakeUser(2, "u2", DateTime.UtcNow.AddDays(-1));
+        var group = EntityFactory.MakeGroup(1, "Group");
+        var tournament = new SingleEliminationBracketTournament
+        {
+            Name = "Tournament",
+            Status = TournamentStatus.InProgress,
+            Group = group,
+            CreatedBy = user1,
+            CreatedAt = DateTime.UtcNow.AddHours(-1),
+            MatchmakingType = TournamentMatchmakingType.SingleEliminationBracket
+        };
+        var oldest = DateTime.UtcNow.AddMinutes(-4);
+        var friendly = new FriendlyPendingDuel
+        {
+            Id = 1,
+            Type = PendingDuelType.Friendly,
+            CreatedAt = oldest,
+            User1 = user1,
+            User2 = user2,
+            Configuration = null,
+            IsAccepted = false
+        };
+        var groupDuel = new GroupPendingDuel
+        {
+            Id = 2,
+            Type = PendingDuelType.Group,
+            CreatedAt = oldest.AddMinutes(1),
+            Group = group,
+            CreatedBy = user1,
+            User1 = user1,
+            User2 = user2,
+            Configuration = null,
+            IsAcceptedByUser1 = true,
+            IsAcceptedByUser2 = false
+        };
+        var tournamentDuel = new TournamentPendingDuel
+        {
+            Id = 3,
+            Type = PendingDuelType.Tournament,
+            CreatedAt = oldest.AddMinutes(2),
+            Tournament = tournament,
+            User1 = user1,
+            User2 = user2,
+            Configuration = null,
+            IsAcceptedByUser1 = true,
+            IsAcceptedByUser2 = true
+        };
+        var ranked = new RankedPendingDuel
+        {
+            Id = 4,
+            Type = PendingDuelType.Ranked,
+            CreatedAt = oldest.AddMinutes(3),
+            User = user2,
+            Rating = 1700
+        };
+
+        Context.Users.AddRange(user1, user2);
+        Context.Groups.Add(group);
+        Context.Tournaments.Add(tournament);
+        Context.PendingDuels.AddRange(friendly, groupDuel, tournamentDuel, ranked);
+        await Context.SaveChangesAsync();
+
+        var pendingResult = await new GetPendingDuelsHandler(Context)
+            .Handle(new GetPendingDuelsQuery(), CancellationToken.None);
+        var searchersResult = await new GetRankedDuelSearchersHandler(Context)
+            .Handle(new GetRankedDuelSearchersQuery(), CancellationToken.None);
+
+        pendingResult.Value.Select(duel => duel.Type).Should().Equal(
+            PendingDuelType.Tournament,
+            PendingDuelType.Group,
+            PendingDuelType.Friendly);
+        pendingResult.Value[0].TournamentName.Should().Be(tournament.Name);
+        pendingResult.Value[1].GroupName.Should().Be(group.Name);
+        pendingResult.Value[2].IsAcceptedByUser1.Should().BeTrue();
+        pendingResult.Value[2].IsAcceptedByUser2.Should().BeFalse();
+        searchersResult.Value.Should().ContainSingle();
+        searchersResult.Value[0].User.Id.Should().Be(user2.Id);
+        searchersResult.Value[0].Rating.Should().Be(1700);
+        searchersResult.Value[0].SearchStartedAt.Should().Be(ranked.CreatedAt);
+    }
+
+    [Fact]
+    public async Task GetDuels_filters_status_orders_by_start_time_and_maps_for_admin_viewer()
+    {
+        var user1 = EntityFactory.MakeUser(1, "u1");
+        var user2 = EntityFactory.MakeUser(2, "u2");
+        var older = EntityFactory.MakeDuel(1, user1, user2, start: DateTime.UtcNow.AddHours(-2));
+        var newer = EntityFactory.MakeDuel(2, user1, user2, start: DateTime.UtcNow.AddHours(-1));
+        var finished = EntityFactory.MakeDuel(3, user1, user2, start: DateTime.UtcNow.AddHours(-3));
+        finished.Status = DuelStatus.Finished;
+        finished.EndTime = DateTime.UtcNow.AddHours(-2);
+        Context.Users.AddRange(user1, user2);
+        Context.Duels.AddRange(older, newer, finished);
+        await Context.SaveChangesAsync();
+
+        var ratingManager = new Mock<IRatingManager>();
+        ratingManager
+            .Setup(manager => manager.GetRatingChanges(
+                It.IsAny<Duel>(),
+                It.IsAny<int>(),
+                It.IsAny<int>()))
+            .Returns([]);
+        var handler = new GetDuelsByStatusHandler(Context, ratingManager.Object, new TaskService());
+
+        var result = await handler.Handle(
+            new GetDuelsByStatusQuery { Status = DuelStatus.InProgress },
+            CancellationToken.None);
+
+        result.Value.Select(duel => duel.Id).Should().Equal(newer.Id, older.Id);
+        result.Value.Should().OnlyContain(duel => duel.OpponentSolutions != null);
+    }
+
+    [Fact]
+    public async Task GetSubmissions_returns_testing_and_all_lists_ordered_by_submit_time()
+    {
+        var user1 = EntityFactory.MakeUser(1, "u1");
+        var user2 = EntityFactory.MakeUser(2, "u2");
+        var duel = EntityFactory.MakeDuel(1, user1, user2);
+        var queued = EntityFactory.MakeSubmission(
+            1,
+            duel,
+            user1,
+            time: DateTime.UtcNow.AddMinutes(-3),
+            status: SubmissionStatus.Queued);
+        var running = EntityFactory.MakeSubmission(
+            2,
+            duel,
+            user2,
+            time: DateTime.UtcNow.AddMinutes(-2),
+            status: SubmissionStatus.Running);
+        var done = EntityFactory.MakeSubmission(
+            3,
+            duel,
+            user1,
+            time: DateTime.UtcNow.AddMinutes(-1),
+            status: SubmissionStatus.Done);
+        Context.Users.AddRange(user1, user2);
+        Context.Duels.Add(duel);
+        Context.Submissions.AddRange(queued, running, done);
+        await Context.SaveChangesAsync();
+
+        var handler = new GetAllSubmissionsHandler(Context);
+        var testingResult = await handler.Handle(
+            new GetAllSubmissionsQuery { OnlyTesting = true },
+            CancellationToken.None);
+        var allResult = await handler.Handle(new GetAllSubmissionsQuery(), CancellationToken.None);
+
+        testingResult.Value.Select(submission => submission.SubmissionId).Should().Equal(running.Id, queued.Id);
+        allResult.Value.Select(submission => submission.SubmissionId).Should().Equal(done.Id, running.Id, queued.Id);
+    }
+
+    [Fact]
+    public async Task GetGroups_orders_all_groups_by_name()
+    {
+        Context.Groups.AddRange(
+            EntityFactory.MakeGroup(1, "Zulu"),
+            EntityFactory.MakeGroup(2, "Alpha"));
+        await Context.SaveChangesAsync();
+
+        var result = await new GetAllGroupsHandler(Context)
+            .Handle(new GetAllGroupsQuery(), CancellationToken.None);
+
+        result.Value.Select(group => group.Name).Should().Equal("Alpha", "Zulu");
+    }
+
+    [Fact]
+    public async Task GetTournaments_splits_active_and_finished_and_orders_by_creation_time()
+    {
+        var creator = EntityFactory.MakeUser(1, "creator");
+        var group = EntityFactory.MakeGroup(1, "Group");
+        var olderActive = MakeTournament(1, "New", TournamentStatus.New, DateTime.UtcNow.AddHours(-3), group, creator);
+        var newerActive = MakeTournament(
+            2,
+            "In progress",
+            TournamentStatus.InProgress,
+            DateTime.UtcNow.AddHours(-2),
+            group,
+            creator);
+        var finished = MakeTournament(
+            3,
+            "Finished",
+            TournamentStatus.Finished,
+            DateTime.UtcNow.AddHours(-1),
+            group,
+            creator);
+        Context.Users.Add(creator);
+        Context.Groups.Add(group);
+        Context.Tournaments.AddRange(olderActive, newerActive, finished);
+        await Context.SaveChangesAsync();
+
+        var handler = new GetTournamentsByStateHandler(Context);
+        var activeResult = await handler.Handle(
+            new GetTournamentsByStateQuery { Finished = false },
+            CancellationToken.None);
+        var finishedResult = await handler.Handle(
+            new GetTournamentsByStateQuery { Finished = true },
+            CancellationToken.None);
+
+        activeResult.Value.Select(tournament => tournament.Id).Should().Equal(newerActive.Id, olderActive.Id);
+        finishedResult.Value.Should().ContainSingle().Which.Id.Should().Be(finished.Id);
+    }
+
+    private static User MakeUser(int id, string nickname, DateTime createdAt)
+    {
+        return new User
+        {
+            Id = id,
+            Nickname = nickname,
+            PasswordHash = "hash",
+            PasswordSalt = "salt",
+            Rating = 1500,
+            CreatedAt = createdAt
+        };
+    }
+
+    private static Tournament MakeTournament(
+        int id,
+        string name,
+        TournamentStatus status,
+        DateTime createdAt,
+        Group group,
+        User creator)
+    {
+        return new SingleEliminationBracketTournament
+        {
+            Id = id,
+            Name = name,
+            Status = status,
+            Group = group,
+            CreatedBy = creator,
+            CreatedAt = createdAt,
+            MatchmakingType = TournamentMatchmakingType.SingleEliminationBracket
+        };
+    }
+}

--- a/Duely/tests/Duely.Application.Tests/Handlers/GetDuelHandlerTests.cs
+++ b/Duely/tests/Duely.Application.Tests/Handlers/GetDuelHandlerTests.cs
@@ -459,5 +459,43 @@ public class GetDuelHandlerTests : ContextBasedTest
         res.IsFailed.Should().BeTrue();
         res.Errors.Should().ContainSingle(e => e is ForbiddenError);
     }
+
+    [Fact]
+    public async Task Returns_any_duel_with_all_tasks_and_solutions_for_admin()
+    {
+        var u1 = EntityFactory.MakeUser(1, "u1");
+        var u2 = EntityFactory.MakeUser(2, "u2");
+        var duel = EntityFactory.MakeDuel(10, u1, u2, "TASK-10");
+        duel.Configuration.ShouldShowOpponentSolution = false;
+        duel.User1Solutions['A'].Solution = "print('u1')";
+        duel.User2Solutions['A'].Solution = "print('u2')";
+        Context.Users.AddRange(u1, u2);
+        Context.Duels.Add(duel);
+        await Context.SaveChangesAsync();
+
+        var ratingManager = new Mock<IRatingManager>();
+        ratingManager.Setup(m => m.GetRatingChanges(It.IsAny<Duel>(), It.IsAny<int>(), It.IsAny<int>()))
+            .Returns(new Dictionary<DuelResult, int>
+            {
+                [DuelResult.Win] = 10,
+                [DuelResult.Draw] = 0,
+                [DuelResult.Lose] = -10
+            });
+
+        var handler = CreateHandler(Context, ratingManager.Object);
+        var res = await handler.Handle(new GetDuelQuery
+        {
+            UserId = 999,
+            DuelId = duel.Id,
+            IsAdmin = true
+        }, CancellationToken.None);
+
+        res.IsSuccess.Should().BeTrue();
+        res.Value.Tasks['A'].Id.Should().Be("TASK-10");
+        res.Value.ShouldShowOpponentSolution.Should().BeTrue();
+        res.Value.Solutions['A'].Solution.Should().Be("print('u1')");
+        res.Value.OpponentSolutions.Should().NotBeNull();
+        res.Value.OpponentSolutions!['A'].Solution.Should().Be("print('u2')");
+    }
 }
 

--- a/Duely/tests/Duely.Application.Tests/Handlers/GetGroupDuelsHandlerTests.cs
+++ b/Duely/tests/Duely.Application.Tests/Handlers/GetGroupDuelsHandlerTests.cs
@@ -143,4 +143,27 @@ public sealed class GetGroupDuelsHandlerTests : ContextBasedTest
         res.IsFailed.Should().BeTrue();
         res.Errors.Should().ContainSingle(e => e is ForbiddenError);
     }
+
+    [Fact]
+    public async Task Returns_duels_for_admin_without_membership()
+    {
+        var group = EntityFactory.MakeGroup(1, "Alpha");
+        Context.Groups.Add(group);
+        await Context.SaveChangesAsync();
+
+        var handler = new GetGroupDuelsHandler(
+            Context,
+            new GroupPermissionsService(),
+            Mock.Of<IRatingManager>(),
+            new TaskService());
+        var res = await handler.Handle(new GetGroupDuelsQuery
+        {
+            UserId = 999,
+            GroupId = group.Id,
+            IsAdmin = true
+        }, CancellationToken.None);
+
+        res.IsSuccess.Should().BeTrue();
+        res.Value.Should().BeEmpty();
+    }
 }

--- a/Duely/tests/Duely.Application.Tests/Handlers/GetGroupHandlerTests.cs
+++ b/Duely/tests/Duely.Application.Tests/Handlers/GetGroupHandlerTests.cs
@@ -55,6 +55,26 @@ public sealed class GetGroupHandlerTests : ContextBasedTest
     }
 
     [Fact]
+    public async Task Returns_group_for_admin_without_membership()
+    {
+        var group = EntityFactory.MakeGroup(1, "Alpha");
+        Context.Groups.Add(group);
+        await Context.SaveChangesAsync();
+
+        var handler = new GetGroupHandler(Context, new GroupPermissionsService());
+        var res = await handler.Handle(new GetGroupQuery
+        {
+            UserId = 999,
+            GroupId = group.Id,
+            IsAdmin = true
+        }, CancellationToken.None);
+
+        res.IsSuccess.Should().BeTrue();
+        res.Value.Id.Should().Be(group.Id);
+        res.Value.UserRole.Should().BeNull();
+    }
+
+    [Fact]
     public async Task Returns_not_found_when_group_missing()
     {
         var handler = new GetGroupHandler(Context, new GroupPermissionsService());

--- a/Duely/tests/Duely.Application.Tests/Handlers/GetGroupTournamentsHandlerTests.cs
+++ b/Duely/tests/Duely.Application.Tests/Handlers/GetGroupTournamentsHandlerTests.cs
@@ -87,4 +87,23 @@ public sealed class GetGroupTournamentsHandlerTests : ContextBasedTest
         result.IsFailed.Should().BeTrue();
         result.Errors.Should().ContainSingle(e => e is ForbiddenError);
     }
+
+    [Fact]
+    public async Task Returns_tournaments_for_admin_without_membership()
+    {
+        var group = EntityFactory.MakeGroup(1, "Alpha");
+        Context.Groups.Add(group);
+        await Context.SaveChangesAsync();
+
+        var handler = new GetGroupTournamentsHandler(Context, new GroupPermissionsService());
+        var result = await handler.Handle(new GetGroupTournamentsQuery
+        {
+            UserId = 999,
+            GroupId = group.Id,
+            IsAdmin = true
+        }, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeEmpty();
+    }
 }

--- a/Duely/tests/Duely.Application.Tests/Handlers/GetGroupUsersHandlerTests.cs
+++ b/Duely/tests/Duely.Application.Tests/Handlers/GetGroupUsersHandlerTests.cs
@@ -91,4 +91,26 @@ public sealed class GetGroupUsersHandlerTests : ContextBasedTest
         res.IsFailed.Should().BeTrue();
         res.Errors.Should().ContainSingle(e => e is ForbiddenError);
     }
+
+    [Fact]
+    public async Task Returns_users_for_admin_without_membership()
+    {
+        var member = EntityFactory.MakeUser(1, "member");
+        var group = EntityFactory.MakeGroup(1, "Alpha");
+        group.Users.Add(EntityFactory.MakeGroupMembership(member, group, GroupRole.Member));
+        Context.Users.Add(member);
+        Context.Groups.Add(group);
+        await Context.SaveChangesAsync();
+
+        var handler = new GetGroupUsersHandler(Context, new GroupPermissionsService());
+        var res = await handler.Handle(new GetGroupUsersQuery
+        {
+            UserId = 999,
+            GroupId = group.Id,
+            IsAdmin = true
+        }, CancellationToken.None);
+
+        res.IsSuccess.Should().BeTrue();
+        res.Value.Should().ContainSingle(user => user.User.Id == member.Id);
+    }
 }

--- a/Duely/tests/Duely.Application.Tests/Handlers/GetSubmissionHandlerTests.cs
+++ b/Duely/tests/Duely.Application.Tests/Handlers/GetSubmissionHandlerTests.cs
@@ -87,4 +87,30 @@ public class GetSubmissionHandlerTests : ContextBasedTest
         res.Value.Solution.Should().BeEmpty();
         res.Value.Message.Should().BeNull();
     }
+
+    [Fact]
+    public async Task Returns_full_submission_for_admin_when_not_owner()
+    {
+        var u1 = EntityFactory.MakeUser(1, "u1");
+        var u2 = EntityFactory.MakeUser(2, "u2");
+        var duel = EntityFactory.MakeDuel(10, u1, u2, "TASK-10");
+        var sub = EntityFactory.MakeSubmission(100, duel, u1, message: "details");
+        Context.Users.AddRange(u1, u2);
+        Context.Duels.Add(duel);
+        Context.Submissions.Add(sub);
+        await Context.SaveChangesAsync();
+
+        var handler = new GetSubmissionHandler(Context);
+        var res = await handler.Handle(new GetSubmissionQuery
+        {
+            SubmissionId = sub.Id,
+            UserId = 999,
+            DuelId = duel.Id,
+            IsAdmin = true
+        }, CancellationToken.None);
+
+        res.IsSuccess.Should().BeTrue();
+        res.Value.Solution.Should().Be(sub.Solution);
+        res.Value.Message.Should().Be("details");
+    }
 }

--- a/Duely/tests/Duely.Application.Tests/Handlers/GetTournamentHandlerTests.cs
+++ b/Duely/tests/Duely.Application.Tests/Handlers/GetTournamentHandlerTests.cs
@@ -10,6 +10,17 @@ namespace Duely.Application.Tests.Handlers;
 
 public sealed class GetTournamentHandlerTests : ContextBasedTest
 {
+    private static GetTournamentHandler CreateHandler(Duely.Infrastructure.DataAccess.EntityFramework.Context context)
+    {
+        return new GetTournamentHandler(
+            context,
+            new GroupPermissionsService(),
+            new TournamentDetailsMapperResolver(new ITournamentDetailsMapper[]
+            {
+                new SingleEliminationBracketTournamentDetailsMapper()
+            }));
+    }
+
     [Fact]
     public async Task Returns_hydrated_single_elimination_bracket()
     {
@@ -43,13 +54,7 @@ public sealed class GetTournamentHandlerTests : ContextBasedTest
         Context.Tournaments.Add(tournament);
         await Context.SaveChangesAsync();
 
-        var handler = new GetTournamentHandler(
-            Context,
-            new GroupPermissionsService(),
-            new TournamentDetailsMapperResolver(new ITournamentDetailsMapper[]
-            {
-                new SingleEliminationBracketTournamentDetailsMapper()
-            }));
+        var handler = CreateHandler(Context);
         var result = await handler.Handle(new GetTournamentQuery
         {
             UserId = viewer.Id,
@@ -103,13 +108,7 @@ public sealed class GetTournamentHandlerTests : ContextBasedTest
         Context.Tournaments.Add(tournament);
         await Context.SaveChangesAsync();
 
-        var handler = new GetTournamentHandler(
-            Context,
-            new GroupPermissionsService(),
-            new TournamentDetailsMapperResolver(new ITournamentDetailsMapper[]
-            {
-                new SingleEliminationBracketTournamentDetailsMapper()
-            }));
+        var handler = CreateHandler(Context);
 
         var result = await handler.Handle(new GetTournamentQuery
         {
@@ -123,5 +122,45 @@ public sealed class GetTournamentHandlerTests : ContextBasedTest
         result.Value.SingleEliminationBracket.Nodes[1]!.RightIndex.Should().BeNull();
         result.Value.SingleEliminationBracket.Nodes[2]!.LeftIndex.Should().Be(5);
         result.Value.SingleEliminationBracket.Nodes[2]!.RightIndex.Should().Be(6);
+    }
+
+    [Fact]
+    public async Task Returns_tournament_for_admin_without_group_membership()
+    {
+        var creator = EntityFactory.MakeUser(1, "creator");
+        var user1 = EntityFactory.MakeUser(2, "u1");
+        var user2 = EntityFactory.MakeUser(3, "u2");
+        var group = EntityFactory.MakeGroup(1, "Alpha");
+        var tournament = new SingleEliminationBracketTournament
+        {
+            Name = "Cup",
+            Status = TournamentStatus.InProgress,
+            Group = group,
+            CreatedBy = creator,
+            CreatedAt = DateTime.UtcNow,
+            MatchmakingType = TournamentMatchmakingType.SingleEliminationBracket,
+            Nodes =
+            [
+                new SingleEliminationBracketNode(),
+                new SingleEliminationBracketNode { UserId = user1.Id, WinnerUserId = user1.Id },
+                new SingleEliminationBracketNode { UserId = user2.Id, WinnerUserId = user2.Id }
+            ]
+        };
+        tournament.Participants.Add(new TournamentParticipant { Tournament = tournament, User = user1, Seed = 1 });
+        tournament.Participants.Add(new TournamentParticipant { Tournament = tournament, User = user2, Seed = 2 });
+        Context.Users.AddRange(creator, user1, user2);
+        Context.Groups.Add(group);
+        Context.Tournaments.Add(tournament);
+        await Context.SaveChangesAsync();
+
+        var result = await CreateHandler(Context).Handle(new GetTournamentQuery
+        {
+            UserId = 999,
+            TournamentId = tournament.Id,
+            IsAdmin = true
+        }, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Tournament.Id.Should().Be(tournament.Id);
     }
 }

--- a/Duely/tests/Duely.Application.Tests/Handlers/GetUserSubmissionsHandlerTests.cs
+++ b/Duely/tests/Duely.Application.Tests/Handlers/GetUserSubmissionsHandlerTests.cs
@@ -91,6 +91,32 @@ public class GetUserSubmissionsHandlerTests : ContextBasedTest
     }
 
     [Fact]
+    public async Task Returns_both_users_submissions_for_admin_without_duel_access()
+    {
+        var u1 = EntityFactory.MakeUser(1, "u1");
+        var u2 = EntityFactory.MakeUser(2, "u2");
+        var duel = EntityFactory.MakeDuel(10, u1, u2, "TASK");
+        Context.Users.AddRange(u1, u2);
+        Context.Duels.Add(duel);
+        Context.Submissions.Add(EntityFactory.MakeSubmission(1, duel, u1, taskKey: 'A'));
+        Context.Submissions.Add(EntityFactory.MakeSubmission(2, duel, u2, taskKey: 'A'));
+        await Context.SaveChangesAsync();
+
+        var handler = new GetUserSubmissionsHandler(Context, new GroupPermissionsService());
+        var res = await handler.Handle(new GetUserSubmissionsQuery
+        {
+            UserId = 999,
+            DuelId = duel.Id,
+            TaskKey = 'A',
+            IsAdmin = true
+        }, CancellationToken.None);
+
+        res.IsSuccess.Should().BeTrue();
+        res.Value.Select(submission => submission.SubmissionId).Should().Equal(1, 2);
+        res.Value.Select(submission => submission.Author.Id).Should().Equal(u1.Id, u2.Id);
+    }
+
+    [Fact]
     public async Task Returns_both_users_submissions_for_group_duel_viewer()
     {
         var ctx = Context;

--- a/Duely/tests/Duely.Infrastructure.Api.Http.Tests/AdminControllerAuthorizationTests.cs
+++ b/Duely/tests/Duely.Infrastructure.Api.Http.Tests/AdminControllerAuthorizationTests.cs
@@ -1,0 +1,37 @@
+using System.Reflection;
+using Duely.Infrastructure.Api.Http.Controllers;
+using FluentAssertions;
+using Microsoft.AspNetCore.Authorization;
+using Xunit;
+
+namespace Duely.Infrastructure.Api.Http.Tests;
+
+public sealed class AdminControllerAuthorizationTests
+{
+    public static TheoryData<Type, string> AdminActions => new()
+    {
+        { typeof(UsersController), nameof(UsersController.GetAllForAdminAsync) },
+        { typeof(UsersController), nameof(UsersController.GetActiveForAdminAsync) },
+        { typeof(DuelsController), nameof(DuelsController.GetPendingForAdminAsync) },
+        { typeof(DuelsController), nameof(DuelsController.GetRankedSearchersForAdminAsync) },
+        { typeof(DuelsController), nameof(DuelsController.GetAllActiveForAdminAsync) },
+        { typeof(DuelsController), nameof(DuelsController.GetAllFinishedForAdminAsync) },
+        { typeof(SubmissionsController), nameof(SubmissionsController.GetTestingForAdminAsync) },
+        { typeof(SubmissionsController), nameof(SubmissionsController.GetAllForAdminAsync) },
+        { typeof(GroupsController), nameof(GroupsController.GetAllForAdminAsync) },
+        { typeof(TournamentsController), nameof(TournamentsController.GetActiveForAdminAsync) },
+        { typeof(TournamentsController), nameof(TournamentsController.GetFinishedForAdminAsync) }
+    };
+
+    [Theory]
+    [MemberData(nameof(AdminActions))]
+    public void Admin_action_requires_only_admin_policy(Type controllerType, string methodName)
+    {
+        var method = controllerType.GetMethod(methodName, BindingFlags.Instance | BindingFlags.Public);
+
+        method.Should().NotBeNull();
+        method!.GetCustomAttributes<AuthorizeAttribute>()
+            .Should()
+            .ContainSingle(attribute => attribute.Policy == AuthorizationPolicies.OnlyAdmin);
+    }
+}

--- a/Duely/tests/Duely.Infrastructure.Api.Http.Tests/AdminReadAccessControllerTests.cs
+++ b/Duely/tests/Duely.Infrastructure.Api.Http.Tests/AdminReadAccessControllerTests.cs
@@ -33,17 +33,25 @@ public sealed class AdminReadAccessControllerTests
     }
 
     [Fact]
-    public async Task Submission_details_pass_admin_claim_to_query()
+    public async Task Submission_reads_pass_admin_claim_to_queries()
     {
         var mediator = new Mock<IMediator>();
+        mediator
+            .Setup(m => m.Send(It.IsAny<GetUserSubmissionsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Ok(new List<SubmissionListItemDto>()));
         mediator
             .Setup(m => m.Send(It.IsAny<GetSubmissionQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Ok<SubmissionDto>(null!));
         var userContext = CreateAdminContext();
         var controller = new SubmissionsController(mediator.Object, userContext.Object);
 
+        await controller.GetUserSubmissionsAsync(10, 'A', CancellationToken.None);
         await controller.GetSubmissionAsync(10, 20, CancellationToken.None);
 
+        mediator.Verify(m => m.Send(
+            It.Is<GetUserSubmissionsQuery>(q =>
+                q.UserId == 42 && q.DuelId == 10 && q.TaskKey == 'A' && q.IsAdmin),
+            It.IsAny<CancellationToken>()));
         mediator.Verify(m => m.Send(
             It.Is<GetSubmissionQuery>(q =>
                 q.UserId == 42 && q.DuelId == 10 && q.SubmissionId == 20 && q.IsAdmin),

--- a/Duely/tests/Duely.Infrastructure.Api.Http.Tests/AdminReadAccessControllerTests.cs
+++ b/Duely/tests/Duely.Infrastructure.Api.Http.Tests/AdminReadAccessControllerTests.cs
@@ -1,0 +1,115 @@
+using Duely.Application.UseCases.Dtos;
+using Duely.Application.UseCases.Features.Duels;
+using Duely.Application.UseCases.Features.Groups;
+using Duely.Application.UseCases.Features.Submissions;
+using Duely.Application.UseCases.Features.Tournaments;
+using Duely.Domain.Services.Duels;
+using Duely.Infrastructure.Api.Http.Controllers;
+using Duely.Infrastructure.Api.Http.Services;
+using FluentResults;
+using MediatR;
+using Moq;
+using Xunit;
+
+namespace Duely.Infrastructure.Api.Http.Tests;
+
+public sealed class AdminReadAccessControllerTests
+{
+    [Fact]
+    public async Task Duel_details_pass_admin_claim_to_query()
+    {
+        var mediator = new Mock<IMediator>();
+        mediator
+            .Setup(m => m.Send(It.IsAny<GetDuelQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Ok<DuelDto>(null!));
+        var userContext = CreateAdminContext();
+        var controller = new DuelsController(mediator.Object, userContext.Object, Mock.Of<IRatingManager>());
+
+        await controller.GetAsync(10, CancellationToken.None);
+
+        mediator.Verify(m => m.Send(
+            It.Is<GetDuelQuery>(q => q.UserId == 42 && q.DuelId == 10 && q.IsAdmin),
+            It.IsAny<CancellationToken>()));
+    }
+
+    [Fact]
+    public async Task Submission_details_pass_admin_claim_to_query()
+    {
+        var mediator = new Mock<IMediator>();
+        mediator
+            .Setup(m => m.Send(It.IsAny<GetSubmissionQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Ok<SubmissionDto>(null!));
+        var userContext = CreateAdminContext();
+        var controller = new SubmissionsController(mediator.Object, userContext.Object);
+
+        await controller.GetSubmissionAsync(10, 20, CancellationToken.None);
+
+        mediator.Verify(m => m.Send(
+            It.Is<GetSubmissionQuery>(q =>
+                q.UserId == 42 && q.DuelId == 10 && q.SubmissionId == 20 && q.IsAdmin),
+            It.IsAny<CancellationToken>()));
+    }
+
+    [Fact]
+    public async Task Group_reads_pass_admin_claim_to_every_query()
+    {
+        var mediator = new Mock<IMediator>();
+        mediator
+            .Setup(m => m.Send(It.IsAny<GetGroupQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Ok<GroupDto>(null!));
+        mediator
+            .Setup(m => m.Send(It.IsAny<GetGroupUsersQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Ok(new List<GroupUserDto>()));
+        mediator
+            .Setup(m => m.Send(It.IsAny<GetGroupDuelsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Ok(new List<GroupDuelDto>()));
+        mediator
+            .Setup(m => m.Send(It.IsAny<GetGroupTournamentsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Ok(new List<TournamentDto>()));
+        var userContext = CreateAdminContext();
+        var controller = new GroupsController(mediator.Object, userContext.Object);
+
+        await controller.GetAsync(10, CancellationToken.None);
+        await controller.GetUsersAsync(10, CancellationToken.None);
+        await controller.GetGroupDuelsAsync(10, CancellationToken.None);
+        await controller.GetGroupTournamentsAsync(10, CancellationToken.None);
+
+        mediator.Verify(m => m.Send(
+            It.Is<GetGroupQuery>(q => q.UserId == 42 && q.GroupId == 10 && q.IsAdmin),
+            It.IsAny<CancellationToken>()));
+        mediator.Verify(m => m.Send(
+            It.Is<GetGroupUsersQuery>(q => q.UserId == 42 && q.GroupId == 10 && q.IsAdmin),
+            It.IsAny<CancellationToken>()));
+        mediator.Verify(m => m.Send(
+            It.Is<GetGroupDuelsQuery>(q => q.UserId == 42 && q.GroupId == 10 && q.IsAdmin),
+            It.IsAny<CancellationToken>()));
+        mediator.Verify(m => m.Send(
+            It.Is<GetGroupTournamentsQuery>(q => q.UserId == 42 && q.GroupId == 10 && q.IsAdmin),
+            It.IsAny<CancellationToken>()));
+    }
+
+    [Fact]
+    public async Task Tournament_details_pass_admin_claim_to_query()
+    {
+        var mediator = new Mock<IMediator>();
+        mediator
+            .Setup(m => m.Send(It.IsAny<GetTournamentQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Ok<TournamentDetailsDto>(null!));
+        var userContext = CreateAdminContext();
+        var controller = new TournamentsController(mediator.Object, userContext.Object);
+
+        await controller.GetAsync(10, CancellationToken.None);
+
+        mediator.Verify(m => m.Send(
+            It.Is<GetTournamentQuery>(q => q.UserId == 42 && q.TournamentId == 10 && q.IsAdmin),
+            It.IsAny<CancellationToken>()));
+    }
+
+    private static Mock<IUserContext> CreateAdminContext()
+    {
+        var userContext = new Mock<IUserContext>();
+        userContext.SetupGet(context => context.UserId).Returns(42);
+        userContext.Setup(context => context.IsAdmin()).Returns(true);
+        return userContext;
+    }
+}

--- a/Duely/tests/Duely.Infrastructure.Api.Http.Tests/WebSocketServicesTests.cs
+++ b/Duely/tests/Duely.Infrastructure.Api.Http.Tests/WebSocketServicesTests.cs
@@ -11,20 +11,32 @@ namespace Duely.Infrastructure.Api.Http.Tests;
 public sealed class WebSocketServicesTests
 {
     [Fact]
-    public void GetConnectedUserIds_returns_each_user_until_their_last_connection_is_removed()
+    public void GetLocallyConnectedUserIds_returns_each_user_until_their_last_local_connection_is_removed()
     {
         var manager = new WebSocketConnectionManager();
         var firstUserConnection = manager.AddConnection(42, new Mock<WebSocket>().Object);
         var secondUserConnection = manager.AddConnection(42, new Mock<WebSocket>().Object);
         manager.AddConnection(7, new Mock<WebSocket>().Object);
 
-        manager.GetConnectedUserIds().Should().BeEquivalentTo([42, 7]);
+        manager.GetLocallyConnectedUserIds().Should().BeEquivalentTo([42, 7]);
 
         manager.RemoveConnection(firstUserConnection);
-        manager.GetConnectedUserIds().Should().BeEquivalentTo([42, 7]);
+        manager.GetLocallyConnectedUserIds().Should().BeEquivalentTo([42, 7]);
 
         manager.RemoveConnection(secondUserConnection);
-        manager.GetConnectedUserIds().Should().BeEquivalentTo([7]);
+        manager.GetLocallyConnectedUserIds().Should().BeEquivalentTo([7]);
+    }
+
+    [Fact]
+    public void Connection_managers_keep_presence_isolated_per_process_instance()
+    {
+        var firstInstance = new WebSocketConnectionManager();
+        var secondInstance = new WebSocketConnectionManager();
+        firstInstance.AddConnection(42, new Mock<WebSocket>().Object);
+        secondInstance.AddConnection(7, new Mock<WebSocket>().Object);
+
+        firstInstance.GetLocallyConnectedUserIds().Should().BeEquivalentTo([42]);
+        secondInstance.GetLocallyConnectedUserIds().Should().BeEquivalentTo([7]);
     }
 
     [Fact]

--- a/Duely/tests/Duely.Infrastructure.Api.Http.Tests/WebSocketServicesTests.cs
+++ b/Duely/tests/Duely.Infrastructure.Api.Http.Tests/WebSocketServicesTests.cs
@@ -11,6 +11,23 @@ namespace Duely.Infrastructure.Api.Http.Tests;
 public sealed class WebSocketServicesTests
 {
     [Fact]
+    public void GetConnectedUserIds_returns_each_user_until_their_last_connection_is_removed()
+    {
+        var manager = new WebSocketConnectionManager();
+        var firstUserConnection = manager.AddConnection(42, new Mock<WebSocket>().Object);
+        var secondUserConnection = manager.AddConnection(42, new Mock<WebSocket>().Object);
+        manager.AddConnection(7, new Mock<WebSocket>().Object);
+
+        manager.GetConnectedUserIds().Should().BeEquivalentTo([42, 7]);
+
+        manager.RemoveConnection(firstUserConnection);
+        manager.GetConnectedUserIds().Should().BeEquivalentTo([42, 7]);
+
+        manager.RemoveConnection(secondUserConnection);
+        manager.GetConnectedUserIds().Should().BeEquivalentTo([7]);
+    }
+
+    [Fact]
     public void RemoveConnection_RemovesOnlyTheClosedSocket()
     {
         var manager = new WebSocketConnectionManager();

--- a/docs/processes/README.md
+++ b/docs/processes/README.md
@@ -12,6 +12,7 @@ automatically treated as an approved product rule.
 
 | Process | Document | Main owner |
 | --- | --- | --- |
+| Administrative read access | [Admin resource access](admin-resource-access.md) | Read-query handlers and HTTP controllers |
 | Rating search and automatic pairing | [Ranked matchmaking](ranked-matchmaking.md) | `StartDuelSearchHandler`, `DuelManager`, `DuelMakingJob` |
 | Direct user-to-user invitations | [Friendly duel invitations](friendly-duel-invitations.md) | Friendly invitation handlers |
 | Group-created invitations | [Group duels](group-duels.md) | Group duel invitation handlers |

--- a/docs/processes/admin-resource-access.md
+++ b/docs/processes/admin-resource-access.md
@@ -1,0 +1,47 @@
+# Admin resource access
+
+## 1. Purpose
+
+Allow a system administrator to inspect operational and product state without
+granting group membership or mutation permissions.
+
+## 2. Authentication and authorization
+
+The HTTP layer reads the authenticated user's `is_admin` token claim through
+`IUserContext` and passes the resulting flag to read queries. A caller without
+that claim continues through the existing participant, ownership, membership,
+and group-role checks. Admin-only list endpoints additionally require the
+`OnlyAdmin` authorization policy.
+
+## 3. Read access
+
+An administrator can:
+
+- open any duel and see all task identifiers and both participants' current
+  solutions;
+- open any submission and see its solution and testing message;
+- open any group, its users, its duels, and its tournaments without being a
+  member;
+- open any tournament without belonging to its group.
+
+For an administrator who is not a group member, `GroupDto.user_role` is `null`.
+This distinguishes system-level read access from a group role and prevents the
+client from treating the administrator as an owner or manager.
+
+## 4. Mutation boundary
+
+The admin claim does not bypass checks for creating, updating, starting,
+accepting, inviting, changing roles, excluding users, or leaving groups. Those
+operations keep their existing participant, membership, and role rules.
+
+## 5. Active-user scope
+
+The admin active-user endpoint is intentionally process-local. Its topology and
+restart semantics are documented in
+[User connection lifecycle](user-connection-lifecycle.md#admin-active-user-view).
+
+## 6. Verification
+
+Focused handler tests cover admin and non-admin reads for duels, submissions,
+groups, group users, group duels, group tournaments, and tournament details.
+WebSocket service tests cover the process-local active-user boundary.

--- a/docs/processes/admin-resource-access.md
+++ b/docs/processes/admin-resource-access.md
@@ -19,10 +19,15 @@ An administrator can:
 
 - open any duel and see all task identifiers and both participants' current
   solutions;
-- open any submission and see its solution and testing message;
+- list both participants' submissions for any duel task and open any submission
+  with its solution and testing message;
 - open any group, its users, its duels, and its tournaments without being a
   member;
 - open any tournament without belonging to its group.
+
+Administrative submission-list rows include the owning `duel_id` and `task_key`
+so clients can deep-link from operational lists to the corresponding submission
+detail inside the duel page.
 
 For an administrator who is not a group member, `GroupDto.user_role` is `null`.
 This distinguishes system-level read access from a group role and prevents the

--- a/docs/processes/submission-and-testing.md
+++ b/docs/processes/submission-and-testing.md
@@ -50,9 +50,12 @@ deadline (duel deadline + five minutes, or now + five minutes if already past).
 Submission detail lookup is not restricted to a duel participant: any
 authenticated caller who knows the duel/submission ids receives status,
 language, verdict, and timestamps, while only the submission owner receives the
-solution and diagnostic message. Submission-list lookup gives a participant
-only their own rows; a nonparticipant can see all authors' rows for a Group duel
-only when their current group role has `CanViewDuel` permission.
+solution and diagnostic message. An administrator receives the full solution
+and diagnostic message for any submission. Submission-list lookup gives a
+non-admin participant only their own rows; a nonparticipant can see all authors'
+rows for a Group duel only when their current group role has `CanViewDuel`
+permission. An administrator can list both participants' submissions for any
+duel and task.
 
 ### Submission status
 
@@ -161,9 +164,10 @@ external success if the outbox transaction does not delete the row.
   behavior; a consumer exception terminates its internal loop after logging.
 - Missing submission/run produces not found. Delivery failures do not roll back
   status already committed.
-- Submission detail intentionally redacts solution/message for a nonowner but
-  does not otherwise require duel access; list access applies the participant or
-  Group permission rule. Code-run detail rejects a nonowner.
+- Submission detail intentionally redacts solution/message for a nonowner who is
+  not an administrator but does not otherwise require duel access; list access
+  applies the participant or Group permission rule unless the caller is an
+  administrator. Code-run detail rejects a nonowner.
 - Expired outbox rows are deleted without marking submission/run failed.
 
 ## 13. User-visible result

--- a/docs/processes/user-connection-lifecycle.md
+++ b/docs/processes/user-connection-lifecycle.md
@@ -18,6 +18,7 @@ is absent when a reconnect grace period expires.
 
 - `POST /users/ticket`: generate/replace the user's ticket.
 - WebSocket upgrade at `GET /users/connect?ticket=...`.
+- Admin `GET /users/admin/active`: list users connected to this Duely instance.
 - Text `SolutionUpdated` frames.
 - Client close frame, network failure, request cancellation, or server shutdown.
 
@@ -46,6 +47,16 @@ Several local sockets may be registered for the same user; a new tab/reconnect
 does not close or replace an existing tab. The connection manager keeps the
 `connectionId` to user and socket mappings under one lock and returns a snapshot
 of all sockets when sending a notification.
+
+### Admin active-user view
+
+`GET /users/admin/active` reads the connection manager of the Duely process that
+serves the request and returns each locally connected user once. It does not
+aggregate presence from other Duely instances. The production Ansible playbook
+currently deploys one container named `duely`, so the local snapshot is the
+complete production snapshot only while that single-instance topology remains
+in effect. A future multi-instance deployment must introduce distributed
+presence before this endpoint can be treated as platform-wide.
 
 ### Receive loop
 
@@ -171,11 +182,13 @@ Every currently open tab connected to the same Duely instance should receive a
 notification. There is no backend online/offline event and no cross-instance
 socket routing. The Frontend must obtain a new ticket to reconnect and recover
 active/invitation/submission state through HTTP because messages during
-disconnection are not replayed.
+disconnection are not replayed. The admin active-user endpoint exposes only the
+same process-local presence snapshot.
 
 ## 14. Implementation references
 
 - [UsersController.cs](../../Duely/src/Duely.Infrastructure.Api.Http/Controllers/UsersController.cs)
+- [Duely production playbook](../../Duely/ansible/deploy/playbook.yml)
 - [CreateTicket.cs](../../Duely/src/Duely.Application.UseCases/Features/Users/CreateTicket.cs)
 - [GetByTicket.cs](../../Duely/src/Duely.Application.UseCases/Features/Users/GetByTicket.cs)
 - [UserWebSocketHandler.cs](../../Duely/src/Duely.Infrastructure.Api.Http/Services/WebSockets/UserWebSocketHandler.cs)
@@ -188,6 +201,8 @@ disconnection are not replayed.
 
 Ticket and cleanup handlers have focused tests. The WebSocket service tests
 cover retaining/removing sibling registrations and fan-out to every open socket.
+They also prove that separate connection-manager instances keep independent
+presence snapshots.
 Handler-level integration coverage for close failure and the grace-period timer
 is still absent.
 


### PR DESCRIPTION
## Summary

- add `OnlyAdmin` list endpoints for users, duels, submissions, groups, and tournaments
- allow administrators to inspect any duel, both participants' submission lists, full submission details, any group and its read-only subresources, and any tournament
- include `duel_id` and `task_key` in admin submission-list rows so the frontend can open the owning duel and selected task
- expose active users from the WebSocket connection registry and ranked-search wait metadata
- make the active-user contract explicitly process-local, document the current single-container production topology, and test instance isolation
- return pending-duel acceptance state plus group and tournament references
- keep all mutation permissions unchanged; `GroupDto.user_role` is `null` when an admin is not a member

## Admin list API

- `GET /users/admin/all`
- `GET /users/admin/active`
- `GET /duels/admin/pending`
- `GET /duels/admin/ranked-searchers`
- `GET /duels/admin/active`
- `GET /duels/admin/finished`
- `GET /duels/admin/submissions/testing`
- `GET /duels/admin/submissions/all`
- `GET /groups/admin/all`
- `GET /tournaments/admin/active`
- `GET /tournaments/admin/finished`

Both admin submission endpoints return the regular submission-list fields plus `duel_id` and `task_key`.

## Additional admin read access

- `GET /duels/{duelId}`
- `GET /duels/{duelId}/submissions?taskKey={taskKey}`
- `GET /duels/{duelId}/submissions/{submissionId}`
- `GET /groups/{id}`
- `GET /groups/{id}/users`
- `GET /groups/{id}/duels`
- `GET /groups/{id}/tournaments`
- `GET /tournaments/{id}`

## Verification

- rebased onto `master` at `eb6131e`
- `dotnet test --configuration Release --no-restore --maxcpucount:1 --disable-build-servers` — 445 tests passed
- focused submission access handlers — 10 passed
- focused admin controller tests — 4 passed

Closes #331